### PR TITLE
docs: expand Stellar public API JSDoc

### DIFF
--- a/src/chains/stellar/announcements.ts
+++ b/src/chains/stellar/announcements.ts
@@ -3,15 +3,32 @@ import { bytesToHex } from './utils';
 import { getDeployment } from './deployments';
 
 /**
- * Fetches all stealth address announcements from the Soroban RPC
- * for the specified Stellar network.
+ * Fetches Stellar stealth announcements from the configured Soroban RPC.
  *
- * Uses the `getEvents` JSON-RPC method to query contract events
- * from the announcer contract.
+ * Use this before {@link scanAnnouncements} when a recipient wants to discover
+ * incoming payments. The helper queries the configured announcer contract with
+ * `getEvents`, handles pagination, and parses event XDR into SDK announcement
+ * objects.
  *
- * @param chain The chain identifier (default: "stellar").
- * @param sorobanUrl Optional override for the Soroban RPC URL.
- * @returns Array of announcements.
+ * @param chain - Deployment key from {@link DEPLOYMENTS}; defaults to `stellar`.
+ * @param sorobanUrl - Optional Soroban RPC URL override.
+ * @returns Parsed announcements from the selected announcer contract.
+ * @throws {Error} If the deployment key is unknown or the RPC request fails before returning JSON.
+ *
+ * @example
+ * ```ts
+ * import { fetchAnnouncements, scanAnnouncements } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const announcements = await fetchAnnouncements("stellar");
+ * const matches = scanAnnouncements(
+ *   announcements,
+ *   keys.viewingKey,
+ *   keys.spendingPubKey,
+ *   keys.spendingScalar,
+ * );
+ * ```
+ *
+ * @see {@link getDeployment}
  */
 export async function fetchAnnouncements(
   chain: string = 'stellar',

--- a/src/chains/stellar/constants.ts
+++ b/src/chains/stellar/constants.ts
@@ -1,9 +1,30 @@
-/** Message signed by the user's wallet to derive stealth keys. */
+/**
+ * Deterministic message users sign to derive Stellar stealth keys.
+ *
+ * Changing this value would derive a different spending and viewing key pair
+ * for every wallet, so treat it as protocol-level data that needs a migration
+ * plan before any update.
+ *
+ * @see {@link deriveStealthKeys}
+ */
 export const STEALTH_SIGNING_MESSAGE =
   'Sign this message to generate your Wraith stealth keys.\n\nChain: Stellar\nNote: This signature is used for key derivation only and does not authorize any transaction.';
 
-/** Scheme ID for ed25519-based stealth addresses on Stellar. */
+/**
+ * Scheme identifier used by Stellar announcements for ed25519 stealth addresses.
+ *
+ * Announcements with another scheme id are ignored by the Stellar scanner.
+ *
+ * @see {@link scanAnnouncements}
+ */
 export const SCHEME_ID = 1;
 
-/** Prefix for stealth meta-addresses on Stellar. */
+/**
+ * Prefix that identifies Wraith Stellar stealth meta-addresses.
+ *
+ * The payload after this prefix is the hex-encoded spending public key followed
+ * by the hex-encoded viewing public key.
+ *
+ * @see {@link encodeStealthMetaAddress}
+ */
 export const META_ADDRESS_PREFIX = 'st:xlm:';

--- a/src/chains/stellar/deployments.ts
+++ b/src/chains/stellar/deployments.ts
@@ -1,14 +1,37 @@
+/**
+ * Network endpoints and contract IDs for a Wraith Stellar deployment.
+ *
+ * Use this when building integrations that need to submit Stellar transactions,
+ * query Soroban events, or call the announcer and names contracts directly.
+ *
+ * @see {@link getDeployment}
+ */
 export interface StellarChainDeployment {
+  /** Human-readable network name, for example `testnet`. */
   network: string;
+  /** Stellar network passphrase used when signing transactions. */
   networkPassphrase: string;
+  /** Horizon API URL for account and classic transaction operations. */
   horizonUrl: string;
+  /** Soroban RPC URL for contract calls and event queries. */
   sorobanUrl: string;
+  /** Deployed Soroban contract IDs used by Wraith on this network. */
   contracts: {
+    /** Contract that stores stealth payment announcements. */
     announcer: string;
+    /** Contract that resolves Wraith names to stealth meta-addresses. */
     names: string;
   };
 }
 
+/**
+ * Built-in Stellar deployments supported by the SDK.
+ *
+ * The `stellar` key currently points to the Wraith Stellar testnet deployment
+ * used by examples and announcement scanning.
+ *
+ * @see {@link getDeployment}
+ */
 export const DEPLOYMENTS: Record<string, StellarChainDeployment> = {
   stellar: {
     network: 'testnet',
@@ -22,6 +45,26 @@ export const DEPLOYMENTS: Record<string, StellarChainDeployment> = {
   },
 };
 
+/**
+ * Returns the configured Stellar deployment for a chain key.
+ *
+ * Use this before constructing Horizon/Soroban clients or locating Wraith
+ * contract IDs for a network.
+ *
+ * @param chain - Deployment key, such as `stellar`.
+ * @returns Stellar endpoints, passphrase, and contract IDs for the chain.
+ * @throws {Error} If `chain` is not present in {@link DEPLOYMENTS}.
+ *
+ * @example
+ * ```ts
+ * import { getDeployment } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const deployment = getDeployment("stellar");
+ * console.log(deployment.sorobanUrl, deployment.contracts.announcer);
+ * ```
+ *
+ * @see {@link fetchAnnouncements}
+ */
 export function getDeployment(chain: string): StellarChainDeployment {
   const deployment = DEPLOYMENTS[chain];
   if (!deployment) {

--- a/src/chains/stellar/keys.ts
+++ b/src/chains/stellar/keys.ts
@@ -4,16 +4,29 @@ import type { StealthKeys } from './types';
 import { seedToScalar } from './scalar';
 
 /**
- * Derives stealth spending and viewing keys from a wallet signature.
+ * Derives Stellar stealth spending and viewing keys from a wallet signature.
  *
- * The 64-byte ed25519 signature is domain-separated and hashed
- * to produce two independent ed25519 seeds:
- *   - spendingKey = SHA-256("wraith:spending:" || signature)
- *   - viewingKey  = SHA-256("wraith:viewing:" || signature)
+ * Use this with a 64-byte ed25519 signature of {@link STEALTH_SIGNING_MESSAGE}.
+ * The result is deterministic for the same wallet and signature message, so
+ * keep the returned seeds and scalars private.
  *
- * Each seed is then expanded via SHA-512 and clamped to produce
- * the actual ed25519 scalar (matching how standard ed25519 derives
- * the private scalar from a seed).
+ * @param signature - 64-byte ed25519 signature produced by the user's Stellar wallet.
+ * @returns Spending and viewing seeds, scalars, and public keys for Stellar stealth payments.
+ * @throws {Error} If `signature` is not exactly 64 bytes.
+ *
+ * @example
+ * ```ts
+ * import { Keypair } from "@stellar/stellar-sdk";
+ * import { deriveStealthKeys, STEALTH_SIGNING_MESSAGE } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const keypair = Keypair.random();
+ * const signature = keypair.sign(Buffer.from(STEALTH_SIGNING_MESSAGE));
+ * const keys = deriveStealthKeys(signature);
+ *
+ * console.log(keys.spendingPubKey, keys.viewingPubKey);
+ * ```
+ *
+ * @see {@link encodeStealthMetaAddress} to publish the public keys for senders.
  */
 export function deriveStealthKeys(signature: Uint8Array): StealthKeys {
   if (signature.length !== 64) {

--- a/src/chains/stellar/meta-address.ts
+++ b/src/chains/stellar/meta-address.ts
@@ -4,9 +4,25 @@ import type { StealthMetaAddress } from './types';
 import { bytesToHex, hexToBytes } from './utils';
 
 /**
- * Encodes spending and viewing public keys into a stealth meta-address string.
+ * Encodes Stellar spending and viewing public keys into a stealth meta-address.
  *
- * Format: `st:xlm:<spending_pubkey_hex 32 bytes><viewing_pubkey_hex 32 bytes>`
+ * Share this value with senders or name registries. It contains only public
+ * keys, but it should still be treated as a stable recipient identifier.
+ *
+ * @param spendingPubKey - Recipient's 32-byte ed25519 spending public key.
+ * @param viewingPubKey - Recipient's 32-byte ed25519 viewing public key.
+ * @returns Meta-address in `st:xlm:<spending_pubkey><viewing_pubkey>` format.
+ * @throws {Error} If either key is not 32 bytes or is not a valid ed25519 public key.
+ *
+ * @example
+ * ```ts
+ * import { deriveStealthKeys, encodeStealthMetaAddress } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const keys = deriveStealthKeys(signature);
+ * const metaAddress = encodeStealthMetaAddress(keys.spendingPubKey, keys.viewingPubKey);
+ * ```
+ *
+ * @see {@link decodeStealthMetaAddress}
  */
 export function encodeStealthMetaAddress(
   spendingPubKey: Uint8Array,
@@ -30,9 +46,24 @@ export function encodeStealthMetaAddress(
 }
 
 /**
- * Decodes a stealth meta-address string into its component public keys.
+ * Decodes a Stellar stealth meta-address into spending and viewing public keys.
  *
- * Validates the prefix, length, and that both keys are valid ed25519 points.
+ * Use this on the sender side before calling {@link generateStealthAddress}.
+ * The decoder validates the prefix, payload length, and ed25519 public keys.
+ *
+ * @param metaAddress - Stellar stealth meta-address beginning with `st:xlm:`.
+ * @returns Parsed prefix, spending public key, and viewing public key.
+ * @throws {Error} If the prefix, payload length, hex bytes, or ed25519 points are invalid.
+ *
+ * @example
+ * ```ts
+ * import { decodeStealthMetaAddress, generateStealthAddress } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const { spendingPubKey, viewingPubKey } = decodeStealthMetaAddress("st:xlm:...");
+ * const payment = generateStealthAddress(spendingPubKey, viewingPubKey);
+ * ```
+ *
+ * @see {@link encodeStealthMetaAddress}
  */
 export function decodeStealthMetaAddress(metaAddress: string): StealthMetaAddress {
   if (!metaAddress.startsWith(META_ADDRESS_PREFIX)) {

--- a/src/chains/stellar/scalar.ts
+++ b/src/chains/stellar/scalar.ts
@@ -4,21 +4,35 @@ import { sha256 } from '@noble/hashes/sha256';
 import { StrKey } from '@stellar/stellar-sdk';
 
 /**
- * ed25519 group order (order of the base point).
- * L = 2^252 + 27742317777372353535851937790883648493
+ * ed25519 group order used to reduce Stellar stealth scalars.
+ *
+ * All derived spending scalars are reduced modulo this value before signing or
+ * point multiplication.
+ *
+ * @see {@link hashToScalar}
  */
 export const L = BigInt(
   '7237005577332262213973186563042994240857116359379907606001950938285454250989',
 );
 
 /**
- * Derives the clamped ed25519 scalar from a 32-byte seed.
+ * Derives a clamped ed25519 scalar from a 32-byte seed.
  *
- * This mirrors the standard ed25519 key derivation:
- *   1. h = SHA-512(seed)
- *   2. scalar = clamp(h[0:32])
+ * Use this when converting deterministic Wraith seeds into the scalar form used
+ * by Stellar stealth derivation and signing.
  *
- * Clamping: clear bits 0,1,2 of byte 0; clear bit 7, set bit 6 of byte 31.
+ * @param seed - 32-byte ed25519 seed.
+ * @returns Clamped ed25519 private scalar as a bigint.
+ * @throws This function does not validate length; pass a 32-byte seed.
+ *
+ * @example
+ * ```ts
+ * import { seedToScalar } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const spendingScalar = seedToScalar(spendingSeed);
+ * ```
+ *
+ * @see {@link deriveStealthKeys}
  */
 export function seedToScalar(seed: Uint8Array): bigint {
   const h = sha512(seed);
@@ -33,7 +47,21 @@ export function seedToScalar(seed: Uint8Array): bigint {
 }
 
 /**
- * Converts a 32-byte little-endian array to a bigint scalar.
+ * Converts a little-endian byte array into a bigint scalar.
+ *
+ * This helper is exported for low-level integrations that need the same scalar
+ * encoding used by the Stellar stealth primitives.
+ *
+ * @param bytes - Little-endian scalar bytes.
+ * @returns Scalar represented as a bigint.
+ * @throws This function does not throw for byte-array input.
+ *
+ * @example
+ * ```ts
+ * const scalar = bytesToScalar(new Uint8Array(32));
+ * ```
+ *
+ * @see {@link scalarToBytes}
  */
 export function bytesToScalar(bytes: Uint8Array): bigint {
   let scalar = 0n;
@@ -44,7 +72,21 @@ export function bytesToScalar(bytes: Uint8Array): bigint {
 }
 
 /**
- * Converts a bigint scalar to a 32-byte little-endian Uint8Array.
+ * Converts a bigint scalar into a 32-byte little-endian array.
+ *
+ * Use this when a derived scalar needs to be serialized for Stellar ed25519
+ * signing internals.
+ *
+ * @param scalar - Scalar value to serialize.
+ * @returns 32-byte little-endian scalar.
+ * @throws This function does not throw; values larger than 32 bytes are truncated.
+ *
+ * @example
+ * ```ts
+ * const bytes = scalarToBytes(1n);
+ * ```
+ *
+ * @see {@link bytesToScalar}
  */
 export function scalarToBytes(scalar: bigint): Uint8Array {
   const bytes = new Uint8Array(32);
@@ -57,12 +99,25 @@ export function scalarToBytes(scalar: bigint): Uint8Array {
 }
 
 /**
- * Derives the stealth public key via point addition:
- *   P_stealth = K_spend + s_h * G
+ * Derives a Stellar stealth public key from a spending key and hash scalar.
  *
- * where s_h is the hashed shared secret reduced mod L.
+ * This performs the public-key side of DKSAP: `K_spend + hashScalar * G`.
+ * Senders use it while generating a one-time address; recipients use it while
+ * checking whether an announcement matches.
  *
- * Returns the 32-byte compressed ed25519 public key.
+ * @param spendingPubKey - Recipient's 32-byte ed25519 spending public key.
+ * @param hashScalar - Shared-secret scalar reduced modulo {@link L}.
+ * @returns 32-byte compressed ed25519 public key for the stealth account.
+ * @throws {Error} If `spendingPubKey` is not a valid ed25519 public key.
+ *
+ * @example
+ * ```ts
+ * import { deriveStealthPubKey, hashToScalar } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const stealthPubKey = deriveStealthPubKey(spendingPubKey, hashToScalar(sharedSecret));
+ * ```
+ *
+ * @see {@link pubKeyToStellarAddress}
  */
 export function deriveStealthPubKey(spendingPubKey: Uint8Array, hashScalar: bigint): Uint8Array {
   const K_spend = ed25519.ExtendedPoint.fromHex(spendingPubKey);
@@ -72,7 +127,23 @@ export function deriveStealthPubKey(spendingPubKey: Uint8Array, hashScalar: bigi
 }
 
 /**
- * Converts a 32-byte ed25519 public key to a Stellar G... address.
+ * Converts a 32-byte ed25519 public key into a Stellar `G...` address.
+ *
+ * Use this after deriving a stealth public key to get the account string that
+ * can be funded on Stellar.
+ *
+ * @param pubKeyBytes - 32-byte ed25519 public key.
+ * @returns Stellar StrKey public account address.
+ * @throws {Error} If Stellar StrKey encoding rejects the public key bytes.
+ *
+ * @example
+ * ```ts
+ * import { pubKeyToStellarAddress } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const account = pubKeyToStellarAddress(stealthPubKey);
+ * ```
+ *
+ * @see {@link deriveStealthPubKey}
  */
 export function pubKeyToStellarAddress(pubKeyBytes: Uint8Array): string {
   // StrKey typings expect Buffer, but Uint8Array works at runtime
@@ -80,10 +151,24 @@ export function pubKeyToStellarAddress(pubKeyBytes: Uint8Array): string {
 }
 
 /**
- * Hashes a shared secret to produce a scalar mod L.
+ * Hashes an ECDH shared secret into a Stellar stealth scalar.
  *
- * hash_scalar = SHA-256("wraith:scalar:" || shared_secret) interpreted
- * as a little-endian integer, reduced mod L.
+ * The hash is domain-separated with `wraith:scalar:` and reduced modulo
+ * {@link L}. Use the result for public-key derivation and private-scalar
+ * derivation.
+ *
+ * @param sharedSecret - 32-byte shared secret from {@link computeSharedSecret}.
+ * @returns Shared-secret scalar reduced modulo {@link L}.
+ * @throws This function does not throw for byte-array input.
+ *
+ * @example
+ * ```ts
+ * import { computeSharedSecret, hashToScalar } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const hashScalar = hashToScalar(computeSharedSecret(viewingKey, ephemeralPubKey));
+ * ```
+ *
+ * @see {@link deriveStealthPubKey}
  */
 export function hashToScalar(sharedSecret: Uint8Array): bigint {
   const prefix = new TextEncoder().encode('wraith:scalar:');
@@ -97,17 +182,25 @@ export function hashToScalar(sharedSecret: Uint8Array): bigint {
 }
 
 /**
- * Signs a message using a raw ed25519 scalar (not a seed).
+ * Signs a message with a raw ed25519 scalar instead of a seed.
  *
- * Implements the ed25519 signature algorithm:
- *   1. Generate deterministic nonce: r = SHA-512(prefix || message) mod L
- *   2. R = r * G
- *   3. k = SHA-512(R || A || message) mod L
- *   4. S = (r + k * a) mod L
- *   5. signature = R || S  (64 bytes)
+ * Stellar stealth private keys are derived scalars, not raw ed25519 seeds. This
+ * helper implements deterministic ed25519 signing directly for those scalars.
  *
- * The "prefix" for nonce generation is derived from SHA-256 of the scalar,
- * providing determinism without needing the original seed.
+ * @param message - Message or transaction hash bytes to sign.
+ * @param scalar - Raw ed25519 private scalar.
+ * @param publicKey - 32-byte public key corresponding to `scalar`.
+ * @returns 64-byte ed25519 signature.
+ * @throws This function does not validate key correspondence; callers must pass the matching public key.
+ *
+ * @example
+ * ```ts
+ * import { signWithScalar } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const signature = signWithScalar(txHash, match.stealthPrivateScalar, match.stealthPubKeyBytes);
+ * ```
+ *
+ * @see {@link signStellarTransaction}
  */
 export function signWithScalar(
   message: Uint8Array,

--- a/src/chains/stellar/scan.ts
+++ b/src/chains/stellar/scan.ts
@@ -5,16 +5,32 @@ import type { Announcement, MatchedAnnouncement } from './types';
 import { hexToBytes } from './utils';
 
 /**
- * Checks whether a single announcement belongs to the recipient.
+ * Checks whether one Stellar announcement can belong to a recipient.
  *
- * Uses only the viewing key and spending PUBLIC key (no spending private key):
- *   1. Compute shared secret: S = ECDH(viewing_key, R_ephemeral)
- *   2. View tag quick filter (eliminates ~255/256 non-matches)
- *   3. Compute hash_scalar = SHA-256("wraith:scalar:" || S) mod L
- *   4. Expected stealth pubkey = K_spend + hash_scalar * G
- *   5. Compare with announced stealth address
+ * This is view-only detection. It uses the viewing key and spending public key
+ * to reconstruct the expected stealth account, but it cannot derive the private
+ * scalar needed to spend.
  *
- * This is view-only: it can detect payments but NOT derive the spending key.
+ * @param ephemeralPubKey - 32-byte ephemeral public key from the announcement.
+ * @param viewingKey - Recipient's 32-byte viewing seed.
+ * @param spendingPubKey - Recipient's 32-byte spending public key.
+ * @param viewTag - One-byte view tag from announcement metadata.
+ * @returns Match status plus the derived address and scalar details when matched.
+ * @throws {Error} If the ephemeral or spending public key is not a valid ed25519 point.
+ *
+ * @example
+ * ```ts
+ * import { checkStealthAddress, hexToBytes } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const result = checkStealthAddress(
+ *   hexToBytes(announcement.ephemeralPubKey),
+ *   keys.viewingKey,
+ *   keys.spendingPubKey,
+ *   hexToBytes(announcement.metadata)[0],
+ * );
+ * ```
+ *
+ * @see {@link scanAnnouncements}
  */
 export function checkStealthAddress(
   ephemeralPubKey: Uint8Array,
@@ -43,15 +59,33 @@ export function checkStealthAddress(
 }
 
 /**
- * Scans a list of on-chain announcements to find those belonging to the recipient.
+ * Scans Stellar stealth announcements and returns the ones a recipient can spend.
  *
- * Requires the spending SCALAR (not just public key) to derive the stealth
- * private scalar for each match. This is the key separation:
- *   - Scanning (detection) needs: viewing_key + spending_pubkey
- *   - Spending needs: spending_scalar
+ * Use this after fetching Soroban announcements. The spending scalar is required
+ * because matched results include the derived stealth private scalar for later
+ * transaction signing.
  *
- * The stealth private scalar is: (spending_scalar + hash_scalar) mod L
- * This matches the EVM version: p_stealth = (m + s_h) mod n
+ * @param announcements - Candidate announcements from Soroban events.
+ * @param viewingKey - Recipient's 32-byte viewing seed.
+ * @param spendingPubKey - Recipient's 32-byte spending public key.
+ * @param spendingScalar - Recipient's private spending scalar.
+ * @returns Announcements that match the recipient, each with spendable scalar data.
+ * @throws {Error} If a matching announcement contains malformed public-key data.
+ *
+ * @example
+ * ```ts
+ * import { fetchAnnouncements, scanAnnouncements } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const announcements = await fetchAnnouncements("stellar");
+ * const matches = scanAnnouncements(
+ *   announcements,
+ *   keys.viewingKey,
+ *   keys.spendingPubKey,
+ *   keys.spendingScalar,
+ * );
+ * ```
+ *
+ * @see {@link deriveStealthPrivateScalar}
  */
 export function scanAnnouncements(
   announcements: Announcement[],

--- a/src/chains/stellar/spend.ts
+++ b/src/chains/stellar/spend.ts
@@ -2,20 +2,30 @@ import { computeSharedSecret } from './stealth';
 import { hashToScalar, signWithScalar, L } from './scalar';
 
 /**
- * Derives the stealth private scalar that controls a stealth address.
+ * Derives the private scalar that controls a matched Stellar stealth account.
  *
- * Recipient-side logic (matches EVM: p_stealth = (m + s_h) mod n):
- *   1. S = ECDH(viewing_key, R_ephemeral)
- *   2. hash_scalar = SHA-256("wraith:scalar:" || S) mod L
- *   3. stealth_scalar = (spending_scalar + hash_scalar) mod L
+ * Call this on the recipient side after an announcement has matched. The viewing
+ * key detects the payment, but the spending scalar is what makes the resulting
+ * stealth account spendable.
  *
- * Requires the spending SCALAR (private key), not just the public key.
- * The viewing key alone cannot derive this — it can only detect matches.
+ * @param spendingScalar - Recipient's private spending scalar.
+ * @param viewingKey - Recipient's 32-byte viewing seed used for ECDH.
+ * @param ephemeralPubKey - 32-byte ephemeral public key from the announcement.
+ * @returns Stealth private scalar: `(spendingScalar + hashScalar) mod L`.
+ * @throws {Error} If the ephemeral public key cannot be converted for X25519.
  *
- * @param spendingScalar  Recipient's spending private scalar.
- * @param viewingKey      Recipient's 32-byte viewing seed (for ECDH).
- * @param ephemeralPubKey The 32-byte ephemeral public key from the announcement.
- * @returns The stealth private scalar.
+ * @example
+ * ```ts
+ * import { deriveStealthPrivateScalar, hexToBytes } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const stealthScalar = deriveStealthPrivateScalar(
+ *   keys.spendingScalar,
+ *   keys.viewingKey,
+ *   hexToBytes(announcement.ephemeralPubKey),
+ * );
+ * ```
+ *
+ * @see {@link signStellarTransaction}
  */
 export function deriveStealthPrivateScalar(
   spendingScalar: bigint,
@@ -28,16 +38,30 @@ export function deriveStealthPrivateScalar(
 }
 
 /**
- * Signs a Stellar transaction hash using the stealth private scalar.
+ * Signs a Stellar transaction hash with a derived stealth private scalar.
  *
- * This implements ed25519 signing directly with the derived scalar,
- * bypassing Keypair.fromRawEd25519Seed() which cannot produce a
- * keypair for a non-clamped derived scalar.
+ * Use this instead of `Keypair.fromRawEd25519Seed()` because derived stealth
+ * scalars are not raw ed25519 seeds. Add the returned signature to the Stellar
+ * transaction envelope with the matching stealth public key.
  *
- * @param transactionHash  The 32-byte SHA-256 hash of the Stellar transaction envelope.
- * @param stealthScalar    The stealth private scalar.
- * @param stealthPubKey    The 32-byte stealth public key.
+ * @param transactionHash - 32-byte SHA-256 hash of the Stellar transaction envelope.
+ * @param stealthScalar - Private scalar derived for the matched stealth account.
+ * @param stealthPubKey - 32-byte stealth public key that corresponds to the scalar.
  * @returns 64-byte ed25519 signature.
+ * @throws This function does not validate lengths; malformed inputs may produce unusable signatures.
+ *
+ * @example
+ * ```ts
+ * import { signStellarTransaction } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const signature = signStellarTransaction(
+ *   tx.hash(),
+ *   match.stealthPrivateScalar,
+ *   match.stealthPubKeyBytes,
+ * );
+ * ```
+ *
+ * @see {@link signWithScalar}
  */
 export function signStellarTransaction(
   transactionHash: Uint8Array,

--- a/src/chains/stellar/stealth.ts
+++ b/src/chains/stellar/stealth.ts
@@ -6,22 +6,30 @@ import type { GeneratedStealthAddress } from './types';
 import { hashToScalar, deriveStealthPubKey, pubKeyToStellarAddress } from './scalar';
 
 /**
- * Generates a one-time stealth address for a recipient on Stellar.
+ * Generates a one-time Stellar stealth address for a recipient.
  *
- * Uses proper ed25519 point addition (matching EVM's DKSAP):
- *   1. Generate ephemeral ed25519 keypair (r, R)
- *   2. ECDH: shared_secret = X25519(r, V_recipient)
- *   3. hash_scalar = SHA-256("wraith:scalar:" || shared_secret) mod L
- *   4. view_tag = SHA-256("wraith:tag:" || shared_secret)[0]
- *   5. P_stealth = K_spend + hash_scalar * G   (point addition)
- *   6. stealth_address = Stellar encoding of P_stealth
+ * Call this on the sender side after decoding a recipient's Stellar
+ * meta-address. The generated address is a normal `G...` Stellar account that
+ * should be funded with `createAccount` before the announcement is published.
  *
- * The viewing key can verify matches (step 5 uses only public keys).
- * The spending key is needed to derive the stealth private scalar.
+ * @param spendingPubKey - Recipient's 32-byte ed25519 spending public key.
+ * @param viewingPubKey - Recipient's 32-byte ed25519 viewing public key.
+ * @param ephemeralSeed - Optional 32-byte seed for deterministic tests.
+ * @returns Stealth account address, ephemeral public key, and 1-byte view tag.
+ * @throws {Error} If a public key cannot be decoded as an ed25519 point.
  *
- * @param spendingPubKey  Recipient's 32-byte ed25519 spending public key.
- * @param viewingPubKey   Recipient's 32-byte ed25519 viewing public key.
- * @param ephemeralSeed   Optional 32-byte seed for deterministic testing.
+ * @example
+ * ```ts
+ * import { decodeStealthMetaAddress, generateStealthAddress } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const { spendingPubKey, viewingPubKey } = decodeStealthMetaAddress(metaAddress);
+ * const { stealthAddress, ephemeralPubKey, viewTag } = generateStealthAddress(
+ *   spendingPubKey,
+ *   viewingPubKey,
+ * );
+ * ```
+ *
+ * @see {@link scanAnnouncements} to detect announcements for generated addresses.
  */
 export function generateStealthAddress(
   spendingPubKey: Uint8Array,
@@ -49,8 +57,25 @@ export function generateStealthAddress(
 }
 
 /**
- * Computes the X25519 shared secret between a private key and a public key.
- * Converts ed25519 keys to X25519 (Montgomery form) first.
+ * Computes the X25519 shared secret for Stellar stealth address derivation.
+ *
+ * The helper converts ed25519 keys to Montgomery form before ECDH. Senders use
+ * an ephemeral seed with the recipient viewing public key; recipients use their
+ * viewing key with the sender's ephemeral public key.
+ *
+ * @param privateKey - 32-byte ed25519 seed used for the local side of ECDH.
+ * @param publicKey - 32-byte ed25519 public key from the remote side.
+ * @returns 32-byte shared secret.
+ * @throws {Error} If the public key cannot be converted to Montgomery form.
+ *
+ * @example
+ * ```ts
+ * import { computeSharedSecret } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const sharedSecret = computeSharedSecret(ephemeralSeed, viewingPubKey);
+ * ```
+ *
+ * @see {@link hashToScalar}
  */
 export function computeSharedSecret(privateKey: Uint8Array, publicKey: Uint8Array): Uint8Array {
   const privX = edwardsToMontgomeryPriv(privateKey);
@@ -59,8 +84,23 @@ export function computeSharedSecret(privateKey: Uint8Array, publicKey: Uint8Arra
 }
 
 /**
- * Computes the view tag from a shared secret.
- * view_tag = SHA-256("wraith:tag:" || shared_secret)[0]
+ * Computes the one-byte view tag for a Stellar stealth announcement.
+ *
+ * View tags let scanners reject most unrelated announcements before doing a
+ * full stealth public-key derivation.
+ *
+ * @param sharedSecret - 32-byte ECDH shared secret from {@link computeSharedSecret}.
+ * @returns Integer view tag in the range 0-255.
+ * @throws This function does not throw for byte-array input.
+ *
+ * @example
+ * ```ts
+ * import { computeSharedSecret, computeViewTag } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const tag = computeViewTag(computeSharedSecret(ephemeralSeed, viewingPubKey));
+ * ```
+ *
+ * @see {@link checkStealthAddress}
  */
 export function computeViewTag(sharedSecret: Uint8Array): number {
   const prefix = new TextEncoder().encode('wraith:tag:');

--- a/src/chains/stellar/types.ts
+++ b/src/chains/stellar/types.ts
@@ -1,7 +1,14 @@
-/** A hex-encoded string with 0x prefix. */
+/** Hex-encoded value with a `0x` prefix. */
 export type HexString = `0x${string}`;
 
-/** Spending and viewing key pairs derived from a wallet signature. */
+/**
+ * Spending and viewing key material derived from a Stellar wallet signature.
+ *
+ * Keep the seed and scalar fields private. Public keys can be shared through a
+ * stealth meta-address so senders can generate one-time receiving accounts.
+ *
+ * @see {@link deriveStealthKeys}
+ */
 export interface StealthKeys {
   /** 32-byte spending seed (ed25519). */
   spendingKey: Uint8Array;
@@ -17,8 +24,16 @@ export interface StealthKeys {
   viewingPubKey: Uint8Array;
 }
 
-/** Parsed stealth meta-address components. */
+/**
+ * Parsed Stellar stealth meta-address components.
+ *
+ * The two public keys are safe to share and are enough for senders to generate
+ * a stealth address, but not enough to scan or spend.
+ *
+ * @see {@link decodeStealthMetaAddress}
+ */
 export interface StealthMetaAddress {
+  /** Stellar stealth meta-address prefix, currently `st:xlm:`. */
   prefix: string;
   /** 32-byte spending public key. */
   spendingPubKey: Uint8Array;
@@ -26,17 +41,31 @@ export interface StealthMetaAddress {
   viewingPubKey: Uint8Array;
 }
 
-/** Result of generating a one-time stealth address for a recipient. */
+/**
+ * Result of generating a one-time Stellar stealth account for a recipient.
+ *
+ * The sender funds `stealthAddress` and publishes `ephemeralPubKey` plus the
+ * view tag so the recipient can detect the payment while scanning.
+ *
+ * @see {@link generateStealthAddress}
+ */
 export interface GeneratedStealthAddress {
   /** The Stellar public key (G...) of the stealth address. */
   stealthAddress: string;
   /** 32-byte ephemeral public key (ed25519). */
   ephemeralPubKey: Uint8Array;
-  /** The 1-byte view tag (0–255). */
+  /** The 1-byte view tag (0-255). */
   viewTag: number;
 }
 
-/** A stealth payment announcement. */
+/**
+ * Soroban event payload for a published Stellar stealth payment announcement.
+ *
+ * Announcements are public metadata. They reveal the generated stealth account
+ * and sender/caller, but not which recipient can detect or spend the payment.
+ *
+ * @see {@link fetchAnnouncements}
+ */
 export interface Announcement {
   /** Scheme identifier (1 for ed25519). */
   schemeId: number;
@@ -46,19 +75,22 @@ export interface Announcement {
   caller: string;
   /** 32-byte ephemeral public key (hex-encoded). */
   ephemeralPubKey: string;
-  /** Hex-encoded metadata (first byte is view tag). */
+  /** Hex-encoded metadata; the first byte is the view tag. */
   metadata: string;
 }
 
 /**
- * An announcement that matched the recipient's viewing key.
- * Contains the stealth private scalar needed to spend.
- * Deriving this scalar requires the spending key — the viewing key alone
- * can only detect matches, not spend.
+ * Announcement that matched the recipient's viewing key.
+ *
+ * Matched announcements include the derived private scalar needed to sign from
+ * the stealth account. The viewing key alone can detect matches, but deriving
+ * this result also requires the recipient's spending scalar.
+ *
+ * @see {@link scanAnnouncements}
  */
 export interface MatchedAnnouncement extends Announcement {
   /** The stealth private scalar: (spending_scalar + hash_scalar) mod L. */
   stealthPrivateScalar: bigint;
-  /** 32-byte stealth public key bytes (for signing helper). */
+  /** 32-byte stealth public key bytes used by the signing helpers. */
   stealthPubKeyBytes: Uint8Array;
 }

--- a/src/chains/stellar/utils.ts
+++ b/src/chains/stellar/utils.ts
@@ -1,5 +1,21 @@
 /**
- * Converts a Uint8Array to a hex string (no 0x prefix).
+ * Converts bytes to a lowercase hex string without a `0x` prefix.
+ *
+ * Use this for serializing Stellar announcement metadata and public keys before
+ * they are written into event payloads.
+ *
+ * @param bytes - Bytes to encode.
+ * @returns Lowercase hex string without a prefix.
+ * @throws This function does not throw for byte-array input.
+ *
+ * @example
+ * ```ts
+ * import { bytesToHex } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const hex = bytesToHex(new Uint8Array([0xab, 0xcd]));
+ * ```
+ *
+ * @see {@link hexToBytes}
  */
 export function bytesToHex(bytes: Uint8Array): string {
   return Array.from(bytes)
@@ -8,7 +24,23 @@ export function bytesToHex(bytes: Uint8Array): string {
 }
 
 /**
- * Converts a hex string (with or without 0x prefix) to a Uint8Array.
+ * Converts a hex string into bytes.
+ *
+ * Accepts either prefixed (`0x...`) or unprefixed hex. Use this when parsing
+ * announcement metadata or stealth meta-address payloads.
+ *
+ * @param hex - Hex string with or without a `0x` prefix.
+ * @returns Parsed bytes.
+ * @throws {Error} If `hex` has an odd number of characters after removing `0x`.
+ *
+ * @example
+ * ```ts
+ * import { hexToBytes } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * const bytes = hexToBytes("abcd");
+ * ```
+ *
+ * @see {@link bytesToHex}
  */
 export function hexToBytes(hex: string): Uint8Array {
   const clean = hex.startsWith('0x') ? hex.slice(2) : hex;


### PR DESCRIPTION
## Summary
- add fuller JSDoc for the Stellar public API exports
- document parameters, returns, throws, examples, and related helpers across the Stellar modules
- expand comments for Stellar deployments, announcements, meta-addresses, scanning, and signing helpers

## Checks
- npm run build
- npm test -- test/chains/stellar
- npm exec --package typedoc -- typedoc src/chains/stellar/index.ts --out .typedoc-stellar --tsconfig tsconfig.json
- git diff --check

Closes #10