### PR TITLE
feat: add Stellar announcement range scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ import {
   signStellarTransaction,
   encodeStealthMetaAddress,
   decodeStealthMetaAddress,
+  fetchAnnouncements,
+  RetentionExceededError,
   SCHEME_ID,
   bytesToHex,
 } from '@wraith-protocol/sdk/chains/stellar';
@@ -188,6 +190,36 @@ const signature = signStellarTransaction(
   matched[0].stealthPrivateScalar,
   matched[0].stealthPubKeyBytes,
 );
+```
+
+### Stellar Incremental Scanning
+
+Use ledger or timestamp bounds to scan only new Soroban announcement events. Persist `nextCursor` after a successful run and pass it back on the next scan; the cursor resumes pagination and takes precedence over `fromLedger`.
+
+```ts
+let cursor = loadCursor();
+
+try {
+  const { announcements, nextCursor } = await fetchAnnouncements('stellar', {
+    cursor,
+    fromTimestamp: cursor ? undefined : new Date(Date.now() - 5 * 60 * 1000),
+  });
+
+  const matched = scanAnnouncements(
+    announcements,
+    keys.viewingKey,
+    keys.spendingPubKey,
+    keys.spendingScalar,
+  );
+
+  saveCursor(nextCursor);
+} catch (error) {
+  if (error instanceof RetentionExceededError) {
+    console.warn(`Restart from ledger ${error.oldestAvailableLedger}`);
+  } else {
+    throw error;
+  }
+}
 ```
 
 ## CKB (Nervos) Stealth Addresses

--- a/examples/stellar/scan-payments.ts
+++ b/examples/stellar/scan-payments.ts
@@ -19,9 +19,12 @@ async function main() {
   const signature = new Uint8Array(64); // wallet.sign(STEALTH_SIGNING_MESSAGE)
   const keys = deriveStealthKeys(signature);
 
-  // 2. Fetch announcements from Soroban RPC
-  const announcements = await fetchAnnouncements('stellar');
+  // 2. Fetch only recent announcements from Soroban RPC and keep the cursor
+  const { announcements, nextCursor } = await fetchAnnouncements('stellar', {
+    fromTimestamp: new Date(Date.now() - 5 * 60 * 1000),
+  });
   console.log(`Found ${announcements.length} total announcements`);
+  console.log(`Next scan cursor: ${nextCursor ?? 'none'}`);
 
   // 3. Scan for payments addressed to us
   const payments = scanAnnouncements(

--- a/src/chains/stellar/announcements.ts
+++ b/src/chains/stellar/announcements.ts
@@ -2,6 +2,38 @@ import type { Announcement } from './types';
 import { bytesToHex } from './utils';
 import { getDeployment } from './deployments';
 
+export interface FetchAnnouncementsOptions {
+  /** Earliest ledger to include, inclusive. Ignored when cursor is provided. */
+  fromLedger?: number;
+  /** Latest ledger to include, exclusive. Defaults to the latest known ledger. */
+  toLedger?: number;
+  /** Convenience lower bound converted to a ledger sequence through Horizon. */
+  fromTimestamp?: Date;
+  /** Convenience upper bound converted to a ledger sequence through Horizon. */
+  toTimestamp?: Date;
+  /** Soroban RPC pagination cursor returned by a previous scan. */
+  cursor?: string;
+}
+
+export interface FetchAnnouncementsResult {
+  announcements: Announcement[];
+  nextCursor?: string;
+}
+
+export class RetentionExceededError extends Error {
+  readonly requestedLedger: number;
+  readonly oldestAvailableLedger: number;
+
+  constructor(requestedLedger: number, oldestAvailableLedger: number) {
+    super(
+      `Requested Stellar ledger ${requestedLedger} is older than the Soroban retention window. Oldest available ledger is ${oldestAvailableLedger}.`,
+    );
+    this.name = 'RetentionExceededError';
+    this.requestedLedger = requestedLedger;
+    this.oldestAvailableLedger = oldestAvailableLedger;
+  }
+}
+
 /**
  * Fetches all stealth address announcements from the Soroban RPC
  * for the specified Stellar network.
@@ -14,17 +46,118 @@ import { getDeployment } from './deployments';
  * @returns Array of announcements.
  */
 export async function fetchAnnouncements(
-  chain: string = 'stellar',
+  chain?: string,
   sorobanUrl?: string,
-): Promise<Announcement[]> {
+): Promise<Announcement[]>;
+export async function fetchAnnouncements(
+  chain: string,
+  opts: FetchAnnouncementsOptions,
+): Promise<FetchAnnouncementsResult>;
+export async function fetchAnnouncements(
+  chain: string,
+  sorobanUrl: string,
+  opts: FetchAnnouncementsOptions,
+): Promise<FetchAnnouncementsResult>;
+export async function fetchAnnouncements(
+  chain: string = 'stellar',
+  sorobanUrlOrOpts?: string | FetchAnnouncementsOptions,
+  maybeOpts?: FetchAnnouncementsOptions,
+): Promise<Announcement[] | FetchAnnouncementsResult> {
   const deployment = getDeployment(chain);
+  const opts = typeof sorobanUrlOrOpts === 'object' ? sorobanUrlOrOpts : maybeOpts;
+  const returnsCursor = Boolean(opts);
+  const sorobanUrl = typeof sorobanUrlOrOpts === 'string' ? sorobanUrlOrOpts : undefined;
   const url = sorobanUrl || deployment.sorobanUrl;
   const announcerContract = deployment.contracts.announcer;
   const all: Announcement[] = [];
 
-  let startLedger = 1;
+  if (opts?.fromLedger !== undefined && opts.fromTimestamp !== undefined) {
+    throw new Error('fromLedger and fromTimestamp are mutually exclusive');
+  }
+  if (opts?.toLedger !== undefined && opts.toTimestamp !== undefined) {
+    throw new Error('toLedger and toTimestamp are mutually exclusive');
+  }
 
-  const probeRes = await fetch(url, {
+  const ledgerWindow = await getSorobanLedgerWindow(url, announcerContract);
+  const latestLedger = ledgerWindow.latest ?? (await getLatestLedger(url));
+  let startLedger =
+    opts?.fromLedger ?? Math.max(ledgerWindow.oldest ?? 1, latestLedger ? latestLedger - 5000 : 1);
+  let toLedger = opts?.toLedger ?? latestLedger;
+
+  if (opts?.fromTimestamp) {
+    startLedger = await ledgerForTimestamp(deployment.horizonUrl, opts.fromTimestamp);
+  }
+  if (opts?.toTimestamp) {
+    toLedger = await ledgerForTimestamp(deployment.horizonUrl, opts.toTimestamp);
+  }
+
+  if (!opts?.cursor && ledgerWindow.oldest !== undefined && startLedger < ledgerWindow.oldest) {
+    throw new RetentionExceededError(startLedger, ledgerWindow.oldest);
+  }
+
+  let cursor = opts?.cursor;
+  let nextCursor: string | undefined = cursor;
+  let hasMore = true;
+
+  while (hasMore) {
+    const params: Record<string, unknown> = {
+      filters: [{ type: 'contract', contractIds: [announcerContract] }],
+      pagination: cursor ? { limit: 1000, cursor } : { limit: 1000 },
+    };
+
+    if (!cursor) {
+      params.startLedger = startLedger;
+    }
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'getEvents',
+        params,
+      }),
+    });
+
+    const data = await res.json();
+    if (data.error?.message) {
+      const range = parseLedgerRange(data.error.message);
+      if (range && !opts?.cursor && startLedger < range.oldest) {
+        throw new RetentionExceededError(startLedger, range.oldest);
+      }
+      break;
+    }
+
+    const events = data.result?.events ?? [];
+
+    for (const event of events) {
+      const ledger = eventLedger(event);
+      if (toLedger !== undefined && ledger !== undefined && ledger >= toLedger) {
+        hasMore = false;
+        continue;
+      }
+      const ann = parseAnnouncementEvent(event);
+      if (ann) all.push(ann);
+    }
+
+    nextCursor = data.result?.cursor ?? cursor;
+    if (!hasMore || events.length < 1000) {
+      hasMore = false;
+    } else {
+      cursor = data.result?.cursor;
+      if (!cursor) hasMore = false;
+    }
+  }
+
+  return returnsCursor ? { announcements: all, nextCursor } : all;
+}
+
+async function getSorobanLedgerWindow(
+  sorobanUrl: string,
+  announcerContract: string,
+): Promise<{ oldest?: number; latest?: number }> {
+  const probeRes = await fetch(sorobanUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -41,54 +174,71 @@ export async function fetchAnnouncements(
 
   const probeData = await probeRes.json();
   if (probeData.error?.message) {
-    const match = probeData.error.message.match(/range:\s*(\d+)\s*-\s*(\d+)/);
-    if (match) {
-      const oldest = parseInt(match[1], 10);
-      const latest = parseInt(match[2], 10);
-      startLedger = Math.max(oldest, latest - 5000);
+    return parseLedgerRange(probeData.error.message) ?? {};
+  }
+  return {};
+}
+
+async function getLatestLedger(sorobanUrl: string): Promise<number | undefined> {
+  const res = await fetch(sorobanUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'getLatestLedger' }),
+  });
+  const data = await res.json();
+  return data.result?.sequence;
+}
+
+async function ledgerForTimestamp(horizonUrl: string, timestamp: Date): Promise<number> {
+  const latest = await horizonLedger(horizonUrl, 'latest');
+  let low = 1;
+  let high = latest.sequence;
+  let answer = latest.sequence + 1;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const ledger = await horizonLedger(horizonUrl, mid);
+    const closedAt = Date.parse(ledger.closed_at);
+
+    if (closedAt >= timestamp.getTime()) {
+      answer = ledger.sequence;
+      high = mid - 1;
     } else {
-      return all;
+      low = mid + 1;
     }
   }
 
-  let cursor: string | undefined;
-  let hasMore = true;
+  return answer;
+}
 
-  while (hasMore) {
-    const params: Record<string, unknown> = {
-      filters: [{ type: 'contract', contractIds: [announcerContract] }],
-      pagination: { limit: 1000 },
-    };
-
-    if (cursor) {
-      params.pagination = { limit: 1000, cursor };
-    } else {
-      params.startLedger = startLedger;
-    }
-
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'getEvents', params }),
-    });
-
-    const data = await res.json();
-    const events = data.result?.events ?? [];
-
-    for (const event of events) {
-      const ann = parseAnnouncementEvent(event);
-      if (ann) all.push(ann);
-    }
-
-    if (events.length < 1000) {
-      hasMore = false;
-    } else {
-      cursor = data.result?.cursor;
-      if (!cursor) hasMore = false;
-    }
+async function horizonLedger(
+  horizonUrl: string,
+  sequence: number | 'latest',
+): Promise<{ sequence: number; closed_at: string }> {
+  const path =
+    sequence === 'latest'
+      ? '/ledgers?order=desc&limit=1'
+      : `/ledgers/${encodeURIComponent(sequence)}`;
+  const res = await fetch(`${horizonUrl}${path}`);
+  const data = await res.json();
+  if (sequence === 'latest') {
+    return data._embedded.records[0];
   }
+  return data;
+}
 
-  return all;
+function parseLedgerRange(message: string): { oldest: number; latest: number } | undefined {
+  const match = message.match(/range:\s*(\d+)\s*-\s*(\d+)/);
+  if (!match) return undefined;
+  return {
+    oldest: parseInt(match[1], 10),
+    latest: parseInt(match[2], 10),
+  };
+}
+
+function eventLedger(event: Record<string, unknown>): number | undefined {
+  const ledger = event.ledger;
+  return typeof ledger === 'number' ? ledger : undefined;
 }
 
 function parseAnnouncementEvent(event: Record<string, unknown>): Announcement | null {

--- a/src/chains/stellar/index.ts
+++ b/src/chains/stellar/index.ts
@@ -13,7 +13,8 @@ export {
   L,
 } from './scalar';
 export { bytesToHex, hexToBytes } from './utils';
-export { fetchAnnouncements } from './announcements';
+export { fetchAnnouncements, RetentionExceededError } from './announcements';
+export type { FetchAnnouncementsOptions, FetchAnnouncementsResult } from './announcements';
 export { DEPLOYMENTS, getDeployment } from './deployments';
 export type { StellarChainDeployment } from './deployments';
 export type {

--- a/test/chains/stellar/announcements.test.ts
+++ b/test/chains/stellar/announcements.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+  fetchAnnouncements,
+  RetentionExceededError,
+} from '../../../src/chains/stellar/announcements';
+
+const sorobanUrl = 'https://soroban-testnet.stellar.org';
+const horizonUrl = 'https://horizon-testnet.stellar.org';
+
+type FetchCall = {
+  url: string;
+  body?: any;
+};
+
+const calls: FetchCall[] = [];
+
+function jsonResponse(body: unknown) {
+  return Promise.resolve({
+    json: () => Promise.resolve(body),
+  } as Response);
+}
+
+function mockFetch(handler: (url: string, body?: any) => unknown) {
+  calls.length = 0;
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const body = init?.body ? JSON.parse(init.body.toString()) : undefined;
+      calls.push({ url, body });
+      return jsonResponse(handler(url, body));
+    }),
+  );
+}
+
+function sorobanRange(oldest = 100, latest = 200) {
+  return {
+    error: {
+      message: `startLedger outside retained range: ${oldest} - ${latest}`,
+    },
+  };
+}
+
+function emptyEvents(cursor = 'next-cursor') {
+  return {
+    result: {
+      events: [],
+      cursor,
+    },
+  };
+}
+
+function methodCalls(method: string) {
+  return calls.filter((call) => call.body?.method === method);
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  calls.length = 0;
+});
+
+describe('fetchAnnouncements Stellar ranges', () => {
+  test('passes an explicit ledger range to Soroban getEvents', async () => {
+    mockFetch((_url, body) => {
+      if (body?.id === 0) return sorobanRange();
+      return {
+        result: {
+          events: [...Array.from({ length: 999 }, () => ({ ledger: 174 })), { ledger: 175 }],
+          cursor: 'range-cursor',
+        },
+      };
+    });
+
+    const result = await fetchAnnouncements('stellar', { fromLedger: 150, toLedger: 175 });
+    const scan = methodCalls('getEvents')[1].body.params;
+
+    expect(scan.startLedger).toBe(150);
+    expect(scan.pagination).toEqual({ limit: 1000 });
+    expect(result).toEqual({ announcements: [], nextCursor: 'range-cursor' });
+    expect(methodCalls('getEvents')).toHaveLength(2);
+  });
+
+  test('uses cursor pagination instead of fromLedger when both are provided', async () => {
+    mockFetch((_url, body) => {
+      if (body?.id === 0) return sorobanRange();
+      return emptyEvents('resume-cursor');
+    });
+
+    await fetchAnnouncements('stellar', { fromLedger: 150, cursor: 'previous-cursor' });
+    const scan = methodCalls('getEvents')[1].body.params;
+
+    expect(scan.startLedger).toBeUndefined();
+    expect(scan.pagination).toEqual({ limit: 1000, cursor: 'previous-cursor' });
+  });
+
+  test('converts timestamps to inclusive and exclusive ledger bounds through Horizon', async () => {
+    mockFetch((url, body) => {
+      if (url === sorobanUrl && body?.id === 0) return sorobanRange(1, 8);
+      if (url === `${horizonUrl}/ledgers?order=desc&limit=1`) {
+        return { _embedded: { records: [{ sequence: 8, closed_at: '2026-01-01T00:08:00Z' }] } };
+      }
+      const sequence = Number(url.split('/').pop());
+      return {
+        sequence,
+        closed_at: `2026-01-01T00:${sequence.toString().padStart(2, '0')}:00Z`,
+      };
+    });
+
+    await fetchAnnouncements('stellar', {
+      fromTimestamp: new Date('2026-01-01T00:04:00Z'),
+      toTimestamp: new Date('2026-01-01T00:07:00Z'),
+    });
+
+    const scan = methodCalls('getEvents')[1].body.params;
+    expect(scan.startLedger).toBe(4);
+  });
+
+  test('throws a typed error when requested fromLedger predates Soroban retention', async () => {
+    mockFetch((_url, body) => {
+      if (body?.id === 0) return sorobanRange(100, 200);
+      return emptyEvents();
+    });
+
+    await expect(fetchAnnouncements('stellar', { fromLedger: 99 })).rejects.toMatchObject({
+      name: 'RetentionExceededError',
+      requestedLedger: 99,
+      oldestAvailableLedger: 100,
+    } satisfies Partial<RetentionExceededError>);
+  });
+
+  test('rejects ambiguous ledger and timestamp lower bounds', async () => {
+    await expect(
+      fetchAnnouncements('stellar', {
+        fromLedger: 10,
+        fromTimestamp: new Date('2026-01-01T00:00:00Z'),
+      }),
+    ).rejects.toThrow('fromLedger and fromTimestamp are mutually exclusive');
+  });
+});


### PR DESCRIPTION
## Summary
- Extend Stellar fetchAnnouncements with ledger/timestamp bounds, cursor resume, and a typed RetentionExceededError
- Preserve legacy array return when called without range options while returning { announcements, nextCursor } for incremental scans
- Add unit coverage for explicit ranges, cursor precedence, timestamp conversion, retention errors, and ambiguous bounds
- Document incremental scanning and update the Stellar scan example

Closes #11

## Follow-up
- Filed Spectre scanner follow-up: wraith-protocol/spectre#1

## Validation
- npx prettier --check .
- npx vitest run
- npx tsc --noEmit
- npx tsup
- git diff --check

Note: local hooks expect pnpm, but pnpm is not available in this shell; the equivalent validation commands above were run with npx.