### PR TITLE
Integrate 3D Gaussian Splatting Viewer for Property Previews

### DIFF
--- a/docs/chains/stellar-view-tag-batching.md
+++ b/docs/chains/stellar-view-tag-batching.md
@@ -1,0 +1,67 @@
+# Stellar view-tag batching design
+
+## Problem
+
+The original Stellar scan path computed `S = X25519(v, R_ephemeral)` for every announcement before checking the view tag. That made the one-byte view tag a correctness filter, but not a performance filter: non-matching announcements still paid the dominant ECDH cost.
+
+## Chosen design
+
+New Stellar announcements derive the first metadata byte from public announcement data:
+
+```text
+view_tag = SHA-256("wraith:stellar:view-tag:v2:" || R_ephemeral || V_recipient)[0]
+```
+
+Where:
+
+- `R_ephemeral` is the 32-byte ed25519 ephemeral public key included in the announcement.
+- `V_recipient` is the recipient's 32-byte ed25519 viewing public key from the meta-address.
+
+This keeps the stealth-address secret scalar unchanged:
+
+```text
+S = X25519(r_ephemeral, V_recipient) = X25519(v_recipient, R_ephemeral)
+hash_scalar = SHA-256("wraith:scalar:" || S) mod L
+P_stealth = K_spend + hash_scalar * G
+```
+
+Scanners now derive `V_recipient` once from the local viewing seed, hash `R_ephemeral || V_recipient` for every announcement, and only compute X25519 plus ed25519 point addition for the roughly 1/256 announcements whose tag matches.
+
+## Tradeoffs
+
+### Benefits
+
+- The hot scan loop replaces nearly all X25519 operations with one SHA-256 over a small public tuple.
+- The full stealth address derivation and private scalar derivation remain unchanged for matching announcements.
+- The filter keeps the same one-byte false-positive rate as the previous shared-secret tag.
+- Invalid 32-byte ephemeral keys are only parsed as curve points after the public tag passes; if a crafted candidate passes the tag but is not a valid point, it is skipped.
+
+### Costs and compatibility
+
+- The view tag is no longer bound to the ECDH shared secret. It is a public prefilter, not authentication. This is acceptable because the announced stealth address is still verified with the shared-secret-derived scalar before a match is returned.
+- A sender that knows a recipient's public viewing key can deliberately choose metadata that passes the recipient's public prefilter. That only causes the recipient to do the same full verification they already needed for candidate announcements, and the stealth address check still prevents false matches.
+- Legacy announcements whose metadata used `SHA-256("wraith:tag:" || S)[0]` are not compatible with the optimized `scanAnnouncements` path. The SDK retains `scanAnnouncementsLegacySharedSecretTag` for benchmarks and migration tooling, but using it for normal scans necessarily reintroduces one X25519 per announcement.
+- If deployed contracts or indexers need to distinguish old and new metadata semantics, this should be represented as a soft fork/new scheme identifier. The SDK-side cryptographic change is isolated to metadata generation and scanning; the stealth-address math does not change.
+
+## Benchmarks
+
+The benchmark harness lives at `test/chains/stellar/bench/scan.bench.ts` and compares:
+
+1. `scanAnnouncementsLegacySharedSecretTag` over legacy shared-secret-tag announcements.
+2. `scanAnnouncements` over new public-announcement-tag announcements.
+
+Run it with:
+
+```bash
+pnpm exec vitest bench test/chains/stellar/bench/scan.bench.ts --run
+```
+
+The harness covers synthetic 10k, 100k, and 1M announcement datasets with one recipient match and a large pool of foreign announcements. Set `STELLAR_SCAN_BENCH_SIZES=10000` (or a comma-separated list) to run a subset locally.
+
+On this development container, the 10k benchmark reported:
+
+| Dataset              | Before: shared-secret tag | After: public prefilter | Speedup |
+| -------------------- | ------------------------: | ----------------------: | ------: |
+| 10,000 announcements |              31,310.03 ms |                98.83 ms | 316.80x |
+
+The expected speedup grows with dataset size because the optimized path computes the viewing public key once and performs X25519 only for public view-tag hits instead of every same-scheme announcement.

--- a/src/chains/stellar/index.ts
+++ b/src/chains/stellar/index.ts
@@ -1,8 +1,17 @@
 export { deriveStealthKeys } from './keys';
 export { STEALTH_SIGNING_MESSAGE, SCHEME_ID, META_ADDRESS_PREFIX } from './constants';
 export { encodeStealthMetaAddress, decodeStealthMetaAddress } from './meta-address';
-export { generateStealthAddress, computeSharedSecret, computeViewTag } from './stealth';
-export { checkStealthAddress, scanAnnouncements } from './scan';
+export {
+  generateStealthAddress,
+  computeSharedSecret,
+  computeAnnouncementViewTag,
+  computeViewTag,
+} from './stealth';
+export {
+  checkStealthAddress,
+  scanAnnouncements,
+  scanAnnouncementsLegacySharedSecretTag,
+} from './scan';
 export { deriveStealthPrivateScalar, signStellarTransaction } from './spend';
 export {
   seedToScalar,

--- a/src/chains/stellar/scan.ts
+++ b/src/chains/stellar/scan.ts
@@ -1,4 +1,5 @@
-import { computeSharedSecret, computeViewTag } from './stealth';
+import { ed25519 } from '@noble/curves/ed25519';
+import { computeAnnouncementViewTag, computeSharedSecret, computeViewTag } from './stealth';
 import { hashToScalar, deriveStealthPubKey, pubKeyToStellarAddress, L } from './scalar';
 import { SCHEME_ID } from './constants';
 import type { Announcement, MatchedAnnouncement } from './types';
@@ -7,12 +8,13 @@ import { hexToBytes } from './utils';
 /**
  * Checks whether a single announcement belongs to the recipient.
  *
- * Uses only the viewing key and spending PUBLIC key (no spending private key):
- *   1. Compute shared secret: S = ECDH(viewing_key, R_ephemeral)
- *   2. View tag quick filter (eliminates ~255/256 non-matches)
- *   3. Compute hash_scalar = SHA-256("wraith:scalar:" || S) mod L
- *   4. Expected stealth pubkey = K_spend + hash_scalar * G
- *   5. Compare with announced stealth address
+ * Uses the cheap public view-tag prefilter before the X25519 shared secret:
+ *   1. Derive the viewing public key once from the viewing seed
+ *   2. View tag quick filter from R_ephemeral || viewing_pubkey
+ *   3. Compute shared secret: S = ECDH(viewing_key, R_ephemeral) only for tag hits
+ *   4. Compute hash_scalar = SHA-256("wraith:scalar:" || S) mod L
+ *   5. Expected stealth pubkey = K_spend + hash_scalar * G
+ *   6. Compare with announced stealth address
  *
  * This is view-only: it can detect payments but NOT derive the spending key.
  */
@@ -27,13 +29,51 @@ export function checkStealthAddress(
   hashScalar: bigint | null;
   stealthPubKeyBytes: Uint8Array | null;
 } {
-  const sharedSecret = computeSharedSecret(viewingKey, ephemeralPubKey);
+  const viewingPubKey = ed25519.getPublicKey(viewingKey);
+  return checkStealthAddressWithViewingPubKey(
+    ephemeralPubKey,
+    viewingKey,
+    viewingPubKey,
+    spendingPubKey,
+    viewTag,
+  );
+}
 
-  const computedTag = computeViewTag(sharedSecret);
+function checkStealthAddressWithViewingPubKey(
+  ephemeralPubKey: Uint8Array,
+  viewingKey: Uint8Array,
+  viewingPubKey: Uint8Array,
+  spendingPubKey: Uint8Array,
+  viewTag: number,
+): {
+  isMatch: boolean;
+  stealthAddress: string | null;
+  hashScalar: bigint | null;
+  stealthPubKeyBytes: Uint8Array | null;
+} {
+  const computedTag = computeAnnouncementViewTag(ephemeralPubKey, viewingPubKey);
   if (computedTag !== viewTag) {
     return { isMatch: false, stealthAddress: null, hashScalar: null, stealthPubKeyBytes: null };
   }
 
+  try {
+    return deriveStealthAddressFromAnnouncement(ephemeralPubKey, viewingKey, spendingPubKey);
+  } catch {
+    return { isMatch: false, stealthAddress: null, hashScalar: null, stealthPubKeyBytes: null };
+  }
+}
+
+function deriveStealthAddressFromAnnouncement(
+  ephemeralPubKey: Uint8Array,
+  viewingKey: Uint8Array,
+  spendingPubKey: Uint8Array,
+): {
+  isMatch: boolean;
+  stealthAddress: string | null;
+  hashScalar: bigint | null;
+  stealthPubKeyBytes: Uint8Array | null;
+} {
+  const sharedSecret = computeSharedSecret(viewingKey, ephemeralPubKey);
   const hScalar = hashToScalar(sharedSecret);
 
   const stealthPubKeyBytes = deriveStealthPubKey(spendingPubKey, hScalar);
@@ -60,6 +100,7 @@ export function scanAnnouncements(
   spendingScalar: bigint,
 ): MatchedAnnouncement[] {
   const matched: MatchedAnnouncement[] = [];
+  const viewingPubKey = ed25519.getPublicKey(viewingKey);
 
   for (const ann of announcements) {
     if (ann.schemeId !== SCHEME_ID) continue;
@@ -71,7 +112,13 @@ export function scanAnnouncements(
     const ephPubKey = hexToBytes(ann.ephemeralPubKey);
     if (ephPubKey.length !== 32) continue;
 
-    const result = checkStealthAddress(ephPubKey, viewingKey, spendingPubKey, viewTag);
+    const result = checkStealthAddressWithViewingPubKey(
+      ephPubKey,
+      viewingKey,
+      viewingPubKey,
+      spendingPubKey,
+      viewTag,
+    );
 
     if (
       result.isMatch &&
@@ -85,6 +132,59 @@ export function scanAnnouncements(
         ...ann,
         stealthPrivateScalar,
         stealthPubKeyBytes: result.stealthPubKeyBytes,
+      });
+    }
+  }
+
+  return matched;
+}
+
+/**
+ * Pre-optimization scanner retained for benchmarks and migration analysis.
+ *
+ * This matches the old Stellar path: every same-scheme announcement pays for
+ * X25519 first, computes the legacy shared-secret tag second, and only then
+ * compares the announced stealth address.
+ */
+export function scanAnnouncementsLegacySharedSecretTag(
+  announcements: Announcement[],
+  viewingKey: Uint8Array,
+  spendingPubKey: Uint8Array,
+  spendingScalar: bigint,
+): MatchedAnnouncement[] {
+  const matched: MatchedAnnouncement[] = [];
+
+  for (const ann of announcements) {
+    if (ann.schemeId !== SCHEME_ID) continue;
+
+    const metadataBytes = hexToBytes(ann.metadata);
+    if (metadataBytes.length === 0) continue;
+    const viewTag = metadataBytes[0];
+
+    const ephPubKey = hexToBytes(ann.ephemeralPubKey);
+    if (ephPubKey.length !== 32) continue;
+
+    let sharedSecret: Uint8Array;
+    try {
+      sharedSecret = computeSharedSecret(viewingKey, ephPubKey);
+    } catch {
+      continue;
+    }
+
+    const computedTag = computeViewTag(sharedSecret);
+    if (computedTag !== viewTag) continue;
+
+    const hScalar = hashToScalar(sharedSecret);
+    const stealthPubKeyBytes = deriveStealthPubKey(spendingPubKey, hScalar);
+    const stealthAddress = pubKeyToStellarAddress(stealthPubKeyBytes);
+
+    if (stealthAddress === ann.stealthAddress) {
+      const stealthPrivateScalar = (spendingScalar + hScalar) % L;
+
+      matched.push({
+        ...ann,
+        stealthPrivateScalar,
+        stealthPubKeyBytes,
       });
     }
   }

--- a/src/chains/stellar/stealth.ts
+++ b/src/chains/stellar/stealth.ts
@@ -2,8 +2,11 @@ import { ed25519 } from '@noble/curves/ed25519';
 import { x25519 } from '@noble/curves/ed25519';
 import { sha256 } from '@noble/hashes/sha256';
 import { edwardsToMontgomeryPub, edwardsToMontgomeryPriv } from '@noble/curves/ed25519';
-import type { GeneratedStealthAddress } from './types';
 import { hashToScalar, deriveStealthPubKey, pubKeyToStellarAddress } from './scalar';
+import type { GeneratedStealthAddress } from './types';
+
+const VIEW_TAG_PREFIX = new TextEncoder().encode('wraith:stellar:view-tag:v2:');
+const LEGACY_VIEW_TAG_PREFIX = new TextEncoder().encode('wraith:tag:');
 
 /**
  * Generates a one-time stealth address for a recipient on Stellar.
@@ -12,7 +15,7 @@ import { hashToScalar, deriveStealthPubKey, pubKeyToStellarAddress } from './sca
  *   1. Generate ephemeral ed25519 keypair (r, R)
  *   2. ECDH: shared_secret = X25519(r, V_recipient)
  *   3. hash_scalar = SHA-256("wraith:scalar:" || shared_secret) mod L
- *   4. view_tag = SHA-256("wraith:tag:" || shared_secret)[0]
+ *   4. view_tag = SHA-256("wraith:stellar:view-tag:v2:" || R || V)[0]
  *   5. P_stealth = K_spend + hash_scalar * G   (point addition)
  *   6. stealth_address = Stellar encoding of P_stealth
  *
@@ -33,7 +36,7 @@ export function generateStealthAddress(
 
   const sharedSecret = computeSharedSecret(ephSeed, viewingPubKey);
 
-  const viewTag = computeViewTag(sharedSecret);
+  const viewTag = computeAnnouncementViewTag(ephPubKey, viewingPubKey);
 
   const hScalar = hashToScalar(sharedSecret);
 
@@ -59,13 +62,38 @@ export function computeSharedSecret(privateKey: Uint8Array, publicKey: Uint8Arra
 }
 
 /**
- * Computes the view tag from a shared secret.
- * view_tag = SHA-256("wraith:tag:" || shared_secret)[0]
+ * Computes the view tag from the public announcement tuple.
+ *
+ * view_tag = SHA-256("wraith:stellar:view-tag:v2:" || R_ephemeral || V_recipient)[0]
+ *
+ * The tag intentionally depends only on public data already present in the
+ * announcement/meta-address. Scanners can reject ~255/256 announcements with
+ * one SHA-256 instead of paying for X25519 first; only candidates that pass
+ * this public prefilter need the full shared-secret derivation.
+ */
+export function computeAnnouncementViewTag(
+  ephemeralPubKey: Uint8Array,
+  viewingPubKey: Uint8Array,
+): number {
+  const input = new Uint8Array(
+    VIEW_TAG_PREFIX.length + ephemeralPubKey.length + viewingPubKey.length,
+  );
+  input.set(VIEW_TAG_PREFIX);
+  input.set(ephemeralPubKey, VIEW_TAG_PREFIX.length);
+  input.set(viewingPubKey, VIEW_TAG_PREFIX.length + ephemeralPubKey.length);
+  return sha256(input)[0];
+}
+
+/**
+ * Computes the legacy view tag from a shared secret.
+ *
+ * @deprecated Stellar scanning now uses computeAnnouncementViewTag() so the
+ * view-tag filter runs before X25519. This function is kept for compatibility
+ * checks and benchmark comparisons with the pre-batching scan path.
  */
 export function computeViewTag(sharedSecret: Uint8Array): number {
-  const prefix = new TextEncoder().encode('wraith:tag:');
-  const input = new Uint8Array(prefix.length + sharedSecret.length);
-  input.set(prefix);
-  input.set(sharedSecret, prefix.length);
+  const input = new Uint8Array(LEGACY_VIEW_TAG_PREFIX.length + sharedSecret.length);
+  input.set(LEGACY_VIEW_TAG_PREFIX);
+  input.set(sharedSecret, LEGACY_VIEW_TAG_PREFIX.length);
   return sha256(input)[0];
 }

--- a/test/chains/stellar/bench/scan.bench.ts
+++ b/test/chains/stellar/bench/scan.bench.ts
@@ -1,0 +1,145 @@
+import { bench, describe, expect, test } from 'vitest';
+import { deriveStealthKeys } from '../../../../src/chains/stellar/keys';
+import {
+  computeAnnouncementViewTag,
+  computeSharedSecret,
+  computeViewTag,
+  generateStealthAddress,
+} from '../../../../src/chains/stellar/stealth';
+import {
+  scanAnnouncements,
+  scanAnnouncementsLegacySharedSecretTag,
+} from '../../../../src/chains/stellar/scan';
+import { SCHEME_ID } from '../../../../src/chains/stellar/constants';
+import { bytesToHex } from '../../../../src/chains/stellar/utils';
+import type { Announcement, StealthKeys } from '../../../../src/chains/stellar/types';
+
+const MATCH_INDEX = 997;
+const POOL_SIZE = 512;
+const DEFAULT_DATASET_SIZES = [10_000, 100_000, 1_000_000] as const;
+const DATASET_SIZES = (
+  process.env.STELLAR_SCAN_BENCH_SIZES?.split(',').map(Number) ?? [...DEFAULT_DATASET_SIZES]
+).filter((size) => Number.isFinite(size) && size > 0);
+const BENCH_OPTIONS = { time: 1, iterations: 1, warmupTime: 0, warmupIterations: 0 };
+
+const keys = deriveStealthKeys(new Uint8Array(64).fill(0xaa));
+const foreignKeys = deriveStealthKeys(new Uint8Array(64).fill(0xbb));
+
+function seedFor(index: number): Uint8Array {
+  const seed = new Uint8Array(32);
+  let state = (index + 1) * 0x9e3779b1;
+  for (let i = 0; i < seed.length; i++) {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    seed[i] = state & 0xff;
+  }
+  return seed;
+}
+
+function makeAnnouncementFor(
+  recipient: StealthKeys,
+  ephemeralSeed: Uint8Array,
+  tagScheme: 'legacy-shared-secret' | 'public-announcement',
+): Announcement {
+  const stealth = generateStealthAddress(
+    recipient.spendingPubKey,
+    recipient.viewingPubKey,
+    ephemeralSeed,
+  );
+  const sharedSecret = computeSharedSecret(ephemeralSeed, recipient.viewingPubKey);
+  const viewTag =
+    tagScheme === 'legacy-shared-secret'
+      ? computeViewTag(sharedSecret)
+      : computeAnnouncementViewTag(stealth.ephemeralPubKey, recipient.viewingPubKey);
+
+  return {
+    schemeId: SCHEME_ID,
+    stealthAddress: stealth.stealthAddress,
+    caller: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    ephemeralPubKey: bytesToHex(stealth.ephemeralPubKey),
+    metadata: viewTag.toString(16).padStart(2, '0'),
+  };
+}
+
+const pools = {
+  legacy: Array.from({ length: POOL_SIZE }, (_, i) =>
+    makeAnnouncementFor(foreignKeys, seedFor(i), 'legacy-shared-secret'),
+  ),
+  optimized: Array.from({ length: POOL_SIZE }, (_, i) =>
+    makeAnnouncementFor(foreignKeys, seedFor(i), 'public-announcement'),
+  ),
+};
+
+const matchingAnnouncements = {
+  legacy: makeAnnouncementFor(keys, seedFor(POOL_SIZE + 1), 'legacy-shared-secret'),
+  optimized: makeAnnouncementFor(keys, seedFor(POOL_SIZE + 1), 'public-announcement'),
+};
+
+function makeDataset(size: number, tagScheme: 'legacy' | 'optimized') {
+  const foreignPool = pools[tagScheme];
+  const matchingAnnouncement = matchingAnnouncements[tagScheme];
+
+  return Array.from({ length: size }, (_, i) =>
+    i === MATCH_INDEX ? matchingAnnouncement : foreignPool[i % foreignPool.length],
+  );
+}
+
+const datasets = new Map(
+  DATASET_SIZES.map((size) => [
+    size,
+    {
+      legacy: makeDataset(size, 'legacy'),
+      optimized: makeDataset(size, 'optimized'),
+    },
+  ]),
+);
+
+describe('Stellar scan benchmark fixtures', () => {
+  test('optimized scanner preserves correctness on the 10k synthetic dataset', () => {
+    const dataset = datasets.get(10_000)?.optimized;
+    expect(dataset).toBeDefined();
+
+    const matched = scanAnnouncements(
+      dataset!,
+      keys.viewingKey,
+      keys.spendingPubKey,
+      keys.spendingScalar,
+    );
+
+    expect(matched).toHaveLength(1);
+    expect(matched[0].stealthAddress).toBe(matchingAnnouncements.optimized.stealthAddress);
+  });
+});
+
+describe('Stellar scan announcement view-tag batching', () => {
+  for (const size of DATASET_SIZES) {
+    const dataset = datasets.get(size)!;
+
+    bench(
+      `before: shared-secret view tag (${size.toLocaleString()} announcements)`,
+      () => {
+        scanAnnouncementsLegacySharedSecretTag(
+          dataset.legacy,
+          keys.viewingKey,
+          keys.spendingPubKey,
+          keys.spendingScalar,
+        );
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      `after: public view-tag prefilter (${size.toLocaleString()} announcements)`,
+      () => {
+        scanAnnouncements(
+          dataset.optimized,
+          keys.viewingKey,
+          keys.spendingPubKey,
+          keys.spendingScalar,
+        );
+      },
+      BENCH_OPTIONS,
+    );
+  }
+});

--- a/test/chains/stellar/scan.test.ts
+++ b/test/chains/stellar/scan.test.ts
@@ -1,6 +1,9 @@
 import { describe, test, expect } from 'vitest';
 import { deriveStealthKeys } from '../../../src/chains/stellar/keys';
-import { generateStealthAddress } from '../../../src/chains/stellar/stealth';
+import {
+  computeAnnouncementViewTag,
+  generateStealthAddress,
+} from '../../../src/chains/stellar/stealth';
 import { checkStealthAddress, scanAnnouncements } from '../../../src/chains/stellar/scan';
 import { SCHEME_ID } from '../../../src/chains/stellar/constants';
 import { bytesToHex } from '../../../src/chains/stellar/utils';
@@ -107,6 +110,34 @@ describe('scanAnnouncements', () => {
       keys.spendingPubKey,
       keys.spendingScalar,
     );
+    expect(matched).toHaveLength(0);
+  });
+
+  test('skips invalid ephemeral keys even when the public view tag matches', () => {
+    const keys = deriveStealthKeys(testSig);
+    const invalidEphemeralPubKey = new Uint8Array(32);
+    const matchingPublicTag = computeAnnouncementViewTag(
+      invalidEphemeralPubKey,
+      keys.viewingPubKey,
+    );
+
+    const announcements: Announcement[] = [
+      {
+        schemeId: SCHEME_ID,
+        stealthAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+        caller: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+        ephemeralPubKey: bytesToHex(invalidEphemeralPubKey),
+        metadata: matchingPublicTag.toString(16).padStart(2, '0'),
+      },
+    ];
+
+    const matched = scanAnnouncements(
+      announcements,
+      keys.viewingKey,
+      keys.spendingPubKey,
+      keys.spendingScalar,
+    );
+
     expect(matched).toHaveLength(0);
   });
 


### PR DESCRIPTION
### Motivation

- Reduce Stellar scan CPU by replacing per-announcement X25519 with a cheap public prefilter so only ~1/256 candidates pay the ECDH cost.

### Description

- Compute announcement view tags from public tuple `R_ephemeral || V_recipient` via `computeAnnouncementViewTag` and keep legacy `computeViewTag` (shared-secret) for compatibility and benchmarking (`src/chains/stellar/stealth.ts`).
- Change scanning to derive the viewing public key once and apply the public view-tag prefilter before computing the X25519 shared secret, refactoring `checkStealthAddress` into `checkStealthAddressWithViewingPubKey` and `deriveStealthAddressFromAnnouncement` (`src/chains/stellar/scan.ts`).
- Add `scanAnnouncementsLegacySharedSecretTag` to preserve the old path for benchmarks/migration and export the new helpers from the Stellar entrypoint (`src/chains/stellar/index.ts`).
- Add a benchmark harness `test/chains/stellar/bench/scan.bench.ts` and documentation `docs/chains/stellar-view-tag-batching.md` describing tradeoffs and measured results.
- Add a test to ensure invalid ephemeral keys that match the public tag are safely skipped and adjust existing tests to the new API (`test/chains/stellar/scan.test.ts`).

### Testing

- Ran unit tests with `pnpm exec vitest run` and all automated tests passed (`27 files`, `135 tests`): success. 
- Ran targeted Stellar tests `pnpm exec vitest run test/chains/stellar/scan.test.ts test/chains/stellar/stealth.test.ts test/chains/stellar/e2e.test.ts`: success. 
- Built the package with `pnpm build`: success. 
- Benchmarked the before/after synthetic scan using the new harness; on this environment the 10k-announcement workload reported ~316.8× speedup (`scanAnnouncementsLegacySharedSecretTag` 31,310.03 ms -> `scanAnnouncements` 98.83 ms).

------

Closes #4 