### PR TITLE
feat(stellar): Soroban error decoder with pluggable registry API

### DIFF
--- a/src/chains/stellar/errors.ts
+++ b/src/chains/stellar/errors.ts
@@ -1,0 +1,345 @@
+import { DEPLOYMENTS } from './deployments';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * Definition of a single Soroban contract error.
+ */
+export interface SorobanContractError {
+  /** Numeric error code returned by the contract. */
+  code: number;
+  /** Human-readable name of the error (e.g. `NameTaken`). */
+  name: string;
+  /** Human-readable description of what the error means. */
+  description: string;
+  /** Optional suggested fix for the end developer. */
+  suggestedFix?: string;
+}
+
+/**
+ * Result of decoding a Soroban contract error.
+ */
+export interface DecodedSorobanError {
+  /** Numeric error code. */
+  code: number;
+  /** Human-readable error name. */
+  name: string;
+  /** Human-readable description. */
+  description: string;
+  /** Suggested fix, if available. */
+  suggestedFix: string | null;
+  /** Contract identifier that was used for the lookup. */
+  contractId: string | null;
+  /** Whether the error was found in a known registry. */
+  isKnown: boolean;
+}
+
+/**
+ * A registry that maps a contract to its set of known error codes.
+ *
+ * Register custom registries with {@link registerErrorRegistry} so that
+ * {@link decodeSorobanError} can decode errors from non-Wraith contracts.
+ */
+export interface ErrorRegistry {
+  /**
+   * Contract identifier — this can be the Soroban contract ID
+   * (e.g. `CCJLJ2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL`)
+   * or a human-readable alias such as `names`.
+   */
+  contractId: string;
+  /** Human-readable contract name for display purposes. */
+  contractName: string;
+  /** Known error definitions for this contract. */
+  errors: SorobanContractError[];
+}
+
+// ---------------------------------------------------------------------------
+// Registry storage
+// ---------------------------------------------------------------------------
+
+const _registries = new Map<string, ErrorRegistry>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a custom error registry so that {@link decodeSorobanError} can
+ * decode errors from the given contract.
+ *
+ * Multiple identifiers can be registered for the same contract by calling
+ * `registerErrorRegistry` more than once with the same error definitions
+ * under different `contractId` values (e.g., a Soroban contract ID and a
+ * human-readable alias).
+ *
+ * @param registry - The error registry to register.
+ *
+ * @example
+ * ```ts
+ * import { registerErrorRegistry, decodeSorobanError } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * registerErrorRegistry({
+ *   contractId: 'CCJLJ2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL',
+ *   contractName: 'My Custom Contract',
+ *   errors: [
+ *     { code: 1, name: 'Unauthorized', description: 'Caller is not authorized.' },
+ *   ],
+ * });
+ * ```
+ */
+export function registerErrorRegistry(registry: ErrorRegistry): void {
+  _registries.set(registry.contractId, registry);
+}
+
+/**
+ * Decode a Soroban contract error code into a human-readable result.
+ *
+ * When `contractId` is provided, the decoder first looks up the registry for
+ * that specific contract. If a match is found, the decoded error is returned.
+ * If the contract is known but the error code is not in its registry, the
+ * returned result will have `isKnown: false` and a descriptive message.
+ *
+ * When `contractId` is omitted, the decoder searches all registered registries
+ * for the error code. If no registry has the error code, a generic fallback
+ * with `isKnown: false` is returned.
+ *
+ * @param errorCode - The numeric error code from the Soroban contract.
+ * @param contractId - Optional contract identifier (Soroban contract ID or
+ *                     registered alias) to scope the lookup.
+ * @returns The decoded error with human-readable fields.
+ *
+ * @example
+ * ```ts
+ * import { decodeSorobanError } from "@wraith-protocol/sdk/chains/stellar";
+ *
+ * // With contract ID
+ * const result = decodeSorobanError(1, 'names');
+ * // { code: 1, name: 'NameTaken', description: '...', isKnown: true }
+ *
+ * // Without contract ID (search all registries)
+ * const result = decodeSorobanError(6);
+ * // { code: 6, name: 'NameNotFound', description: '...', isKnown: true }
+ *
+ * // Unknown error code
+ * const result = decodeSorobanError(99);
+ * // { code: 99, name: 'UnknownError', description: '...', isKnown: false }
+ * ```
+ */
+export function decodeSorobanError(
+  errorCode: number,
+  contractId?: string,
+): DecodedSorobanError {
+  // When contractId is provided, scope the lookup to that contract's registry
+  if (contractId !== undefined) {
+    const registry = _registries.get(contractId);
+    if (registry) {
+      const errorDef = registry.errors.find((e) => e.code === errorCode);
+      if (errorDef) {
+        return {
+          code: errorDef.code,
+          name: errorDef.name,
+          description: errorDef.description,
+          suggestedFix: errorDef.suggestedFix ?? null,
+          contractId: registry.contractId,
+          isKnown: true,
+        };
+      }
+      // Contract is registered but this error code is not in its registry
+      return {
+        code: errorCode,
+        name: 'UnknownError',
+        description: `Unknown error code ${errorCode} for contract "${registry.contractName}" (${registry.contractId}).`,
+        suggestedFix: 'Check the contract source code or open an issue on the Wraith Protocol repository.',
+        contractId: registry.contractId,
+        isKnown: false,
+      };
+    }
+    // Unknown contractId — return fallback
+    return {
+      code: errorCode,
+      name: 'UnknownError',
+      description: `No error registry found for contract "${contractId}".`,
+      suggestedFix: 'Ensure the contract ID is correct. You can register custom registries with registerErrorRegistry().',
+      contractId,
+      isKnown: false,
+    };
+  }
+
+  // No contractId — search all registries for the error code
+  for (const [, registry] of _registries) {
+    const errorDef = registry.errors.find((e) => e.code === errorCode);
+    if (errorDef) {
+      return {
+        code: errorDef.code,
+        name: errorDef.name,
+        description: errorDef.description,
+        suggestedFix: errorDef.suggestedFix ?? null,
+        contractId: registry.contractId,
+        isKnown: true,
+      };
+    }
+  }
+
+  // Fallback: unknown error in any registry
+  return {
+    code: errorCode,
+    name: 'UnknownError',
+    description: `Unrecognized Soroban contract error code ${errorCode}.`,
+    suggestedFix: null,
+    contractId: null,
+    isKnown: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Built-in error definitions
+// ---------------------------------------------------------------------------
+
+const STEALTH_REGISTRY_ERRORS: SorobanContractError[] = [
+  {
+    code: 1,
+    name: 'InvalidMetaAddressLength',
+    description:
+      'The provided stealth meta-address has an invalid length. Expected a properly encoded 64-byte (128 hex chars) payload.',
+    suggestedFix:
+      'Ensure the meta-address is properly encoded using encodeStealthMetaAddress() and is valid for the Stellar network.',
+  },
+  {
+    code: 2,
+    name: 'NotRegistered',
+    description:
+      'The specified account does not have a registered stealth meta-address in the registry.',
+    suggestedFix: 'Register a stealth meta-address first using the registry contract.',
+  },
+];
+
+const SENDER_ERRORS: SorobanContractError[] = [
+  {
+    code: 1,
+    name: 'AlreadyInitialized',
+    description: 'The sender contract has already been initialized.',
+    suggestedFix: 'Do not attempt to re-initialize the sender contract.',
+  },
+  {
+    code: 2,
+    name: 'NotInitialized',
+    description: 'The sender contract has not yet been initialized.',
+    suggestedFix: 'Initialize the contract before using it.',
+  },
+  {
+    code: 3,
+    name: 'LengthMismatch',
+    description: 'Array length mismatch in contract parameters.',
+    suggestedFix:
+      'Ensure all arrays provided to the contract have matching lengths.',
+  },
+];
+
+const NAMES_ERRORS: SorobanContractError[] = [
+  {
+    code: 1,
+    name: 'NameTaken',
+    description:
+      'The requested name is already registered to another account.',
+    suggestedFix: 'Choose a different name that is not yet registered.',
+  },
+  {
+    code: 2,
+    name: 'NameTooShort',
+    description: 'The name is shorter than the minimum allowed length.',
+    suggestedFix: 'Use a name that meets the minimum length requirement.',
+  },
+  {
+    code: 3,
+    name: 'NameTooLong',
+    description: 'The name exceeds the maximum allowed length.',
+    suggestedFix: 'Use a shorter name that fits within the limit.',
+  },
+  {
+    code: 4,
+    name: 'InvalidNameCharacter',
+    description: 'The name contains characters that are not allowed.',
+    suggestedFix:
+      'Use only alphanumeric characters and other allowed special characters.',
+  },
+  {
+    code: 5,
+    name: 'InvalidMetaAddress',
+    description:
+      'The provided stealth meta-address is not valid for registration.',
+    suggestedFix:
+      'Provide a valid stealth meta-address encoded for the Stellar network using encodeStealthMetaAddress().',
+  },
+  {
+    code: 6,
+    name: 'NameNotFound',
+    description:
+      'The specified name was not found in the Wraith Names registry.',
+    suggestedFix: 'Check that the name has been registered.',
+  },
+  {
+    code: 7,
+    name: 'NotOwner',
+    description:
+      'The caller is not the owner of the name and is not authorized to perform this operation.',
+    suggestedFix: 'Use the owner account to perform this operation.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Built-in registry registration
+// ---------------------------------------------------------------------------
+
+/** @internal */
+function registerBuiltinRegistries(): void {
+  // stealth-announcer: no custom errors (stateless event emitter)
+  registerErrorRegistry({
+    contractId: 'announcer',
+    contractName: 'Stealth Announcer',
+    errors: [],
+  });
+
+  // stealth-registry
+  registerErrorRegistry({
+    contractId: 'registry',
+    contractName: 'Stealth Registry',
+    errors: STEALTH_REGISTRY_ERRORS,
+  });
+
+  // stealth-sender
+  registerErrorRegistry({
+    contractId: 'sender',
+    contractName: 'Stealth Sender',
+    errors: SENDER_ERRORS,
+  });
+
+  // wraith-names
+  registerErrorRegistry({
+    contractId: 'names',
+    contractName: 'Wraith Names',
+    errors: NAMES_ERRORS,
+  });
+
+  // Register by known deployed Soroban contract IDs for direct lookup
+  for (const [, deployment] of Object.entries(DEPLOYMENTS)) {
+    if (deployment.contracts.announcer) {
+      registerErrorRegistry({
+        contractId: deployment.contracts.announcer,
+        contractName: 'Stealth Announcer',
+        errors: [],
+      });
+    }
+    if (deployment.contracts.names) {
+      registerErrorRegistry({
+        contractId: deployment.contracts.names,
+        contractName: 'Wraith Names',
+        errors: NAMES_ERRORS,
+      });
+    }
+  }
+}
+
+// Register built-in registries at module load time
+registerBuiltinRegistries();

--- a/src/chains/stellar/errors.ts
+++ b/src/chains/stellar/errors.ts
@@ -127,10 +127,7 @@ export function registerErrorRegistry(registry: ErrorRegistry): void {
  * // { code: 99, name: 'UnknownError', description: '...', isKnown: false }
  * ```
  */
-export function decodeSorobanError(
-  errorCode: number,
-  contractId?: string,
-): DecodedSorobanError {
+export function decodeSorobanError(errorCode: number, contractId?: string): DecodedSorobanError {
   // When contractId is provided, scope the lookup to that contract's registry
   if (contractId !== undefined) {
     const registry = _registries.get(contractId);
@@ -151,7 +148,8 @@ export function decodeSorobanError(
         code: errorCode,
         name: 'UnknownError',
         description: `Unknown error code ${errorCode} for contract "${registry.contractName}" (${registry.contractId}).`,
-        suggestedFix: 'Check the contract source code or open an issue on the Wraith Protocol repository.',
+        suggestedFix:
+          'Check the contract source code or open an issue on the Wraith Protocol repository.',
         contractId: registry.contractId,
         isKnown: false,
       };
@@ -161,7 +159,8 @@ export function decodeSorobanError(
       code: errorCode,
       name: 'UnknownError',
       description: `No error registry found for contract "${contractId}".`,
-      suggestedFix: 'Ensure the contract ID is correct. You can register custom registries with registerErrorRegistry().',
+      suggestedFix:
+        'Ensure the contract ID is correct. You can register custom registries with registerErrorRegistry().',
       contractId,
       isKnown: false,
     };
@@ -232,8 +231,7 @@ const SENDER_ERRORS: SorobanContractError[] = [
     code: 3,
     name: 'LengthMismatch',
     description: 'Array length mismatch in contract parameters.',
-    suggestedFix:
-      'Ensure all arrays provided to the contract have matching lengths.',
+    suggestedFix: 'Ensure all arrays provided to the contract have matching lengths.',
   },
 ];
 
@@ -241,8 +239,7 @@ const NAMES_ERRORS: SorobanContractError[] = [
   {
     code: 1,
     name: 'NameTaken',
-    description:
-      'The requested name is already registered to another account.',
+    description: 'The requested name is already registered to another account.',
     suggestedFix: 'Choose a different name that is not yet registered.',
   },
   {
@@ -261,22 +258,19 @@ const NAMES_ERRORS: SorobanContractError[] = [
     code: 4,
     name: 'InvalidNameCharacter',
     description: 'The name contains characters that are not allowed.',
-    suggestedFix:
-      'Use only alphanumeric characters and other allowed special characters.',
+    suggestedFix: 'Use only alphanumeric characters and other allowed special characters.',
   },
   {
     code: 5,
     name: 'InvalidMetaAddress',
-    description:
-      'The provided stealth meta-address is not valid for registration.',
+    description: 'The provided stealth meta-address is not valid for registration.',
     suggestedFix:
       'Provide a valid stealth meta-address encoded for the Stellar network using encodeStealthMetaAddress().',
   },
   {
     code: 6,
     name: 'NameNotFound',
-    description:
-      'The specified name was not found in the Wraith Names registry.',
+    description: 'The specified name was not found in the Wraith Names registry.',
     suggestedFix: 'Check that the name has been registered.',
   },
   {

--- a/src/chains/stellar/index.ts
+++ b/src/chains/stellar/index.ts
@@ -74,12 +74,5 @@ export type {
 } from './fee-estimation';
 export { buildStellarSwapAndStealth } from './swap';
 export type { BuildStellarSwapAndStealthOptions, SwapAndStealthResult } from './swap';
-export {
-  decodeSorobanError,
-  registerErrorRegistry,
-} from './errors';
-export type {
-  SorobanContractError,
-  DecodedSorobanError,
-  ErrorRegistry,
-} from './errors';
+export { decodeSorobanError, registerErrorRegistry } from './errors';
+export type { SorobanContractError, DecodedSorobanError, ErrorRegistry } from './errors';

--- a/src/chains/stellar/index.ts
+++ b/src/chains/stellar/index.ts
@@ -19,9 +19,8 @@ export {
   checkStealthAddress,
   scanAnnouncements,
   scanAnnouncementsLegacySharedSecretTag,
+  scanAnnouncementsStream,
 } from './scan';
-export { generateStealthAddress, computeSharedSecret, computeViewTag } from './stealth';
-export { checkStealthAddress, scanAnnouncements, scanAnnouncementsStream } from './scan';
 export { deriveStealthPrivateScalar, signStellarTransaction } from './spend';
 export { buildStealthPayment, buildStealthAnnouncement } from './builders';
 export type { BuildStealthPaymentOptions, BuildAnnouncementOptions } from './builders';
@@ -75,3 +74,12 @@ export type {
 } from './fee-estimation';
 export { buildStellarSwapAndStealth } from './swap';
 export type { BuildStellarSwapAndStealthOptions, SwapAndStealthResult } from './swap';
+export {
+  decodeSorobanError,
+  registerErrorRegistry,
+} from './errors';
+export type {
+  SorobanContractError,
+  DecodedSorobanError,
+  ErrorRegistry,
+} from './errors';

--- a/test/chains/stellar/errors.test.ts
+++ b/test/chains/stellar/errors.test.ts
@@ -1,0 +1,300 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import {
+  decodeSorobanError,
+  registerErrorRegistry,
+  type DecodedSorobanError,
+  type ErrorRegistry,
+} from '../../../src/chains/stellar/errors';
+
+describe('decodeSorobanError', () => {
+  // -----------------------------------------------------------------------
+  // Built-in: Stealth Registry
+  // -----------------------------------------------------------------------
+  describe('stealth-registry', () => {
+    test('decodes InvalidMetaAddressLength (code 1)', () => {
+      const result = decodeSorobanError(1, 'registry');
+      expect(result.code).toBe(1);
+      expect(result.name).toBe('InvalidMetaAddressLength');
+      expect(result.description).toBeTruthy();
+      expect(result.suggestedFix).toBeTruthy();
+      expect(result.isKnown).toBe(true);
+      expect(result.contractId).toBe('registry');
+    });
+
+    test('decodes NotRegistered (code 2)', () => {
+      const result = decodeSorobanError(2, 'registry');
+      expect(result.code).toBe(2);
+      expect(result.name).toBe('NotRegistered');
+      expect(result.description).toBeTruthy();
+      expect(result.suggestedFix).toBeTruthy();
+      expect(result.isKnown).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Built-in: Stealth Sender
+  // -----------------------------------------------------------------------
+  describe('stealth-sender', () => {
+    test('decodes AlreadyInitialized (code 1)', () => {
+      const result = decodeSorobanError(1, 'sender');
+      expect(result.code).toBe(1);
+      expect(result.name).toBe('AlreadyInitialized');
+      expect(result.isKnown).toBe(true);
+    });
+
+    test('decodes NotInitialized (code 2)', () => {
+      const result = decodeSorobanError(2, 'sender');
+      expect(result.code).toBe(2);
+      expect(result.name).toBe('NotInitialized');
+      expect(result.isKnown).toBe(true);
+    });
+
+    test('decodes LengthMismatch (code 3)', () => {
+      const result = decodeSorobanError(3, 'sender');
+      expect(result.code).toBe(3);
+      expect(result.name).toBe('LengthMismatch');
+      expect(result.isKnown).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Built-in: Wraith Names
+  // -----------------------------------------------------------------------
+  describe('wraith-names', () => {
+    test('decodes NameTaken (code 1)', () => {
+      const result = decodeSorobanError(1, 'names');
+      expect(result.code).toBe(1);
+      expect(result.name).toBe('NameTaken');
+      expect(result.isKnown).toBe(true);
+    });
+
+    test('decodes NameTooShort (code 2)', () => {
+      const result = decodeSorobanError(2, 'names');
+      expect(result.code).toBe(2);
+      expect(result.name).toBe('NameTooShort');
+      expect(result.isKnown).toBe(true);
+    });
+
+    test('decodes NameTooLong (code 3)', () => {
+      const result = decodeSorobanError(3, 'names');
+      expect(result.code).toBe(3);
+      expect(result.name).toBe('NameTooLong');
+      expect(result.isKnown).toBe(true);
+    });
+
+    test('decodes InvalidNameCharacter (code 4)', () => {
+      const result = decodeSorobanError(4, 'names');
+      expect(result.code).toBe(4);
+      expect(result.name).toBe('InvalidNameCharacter');
+      expect(result.isKnown).toBe(true);
+    });
+
+    test('decodes InvalidMetaAddress (code 5)', () => {
+      const result = decodeSorobanError(5, 'names');
+      expect(result.code).toBe(5);
+      expect(result.name).toBe('InvalidMetaAddress');
+      expect(result.isKnown).toBe(true);
+    });
+
+    test('decodes NameNotFound (code 6)', () => {
+      const result = decodeSorobanError(6, 'names');
+      expect(result.code).toBe(6);
+      expect(result.name).toBe('NameNotFound');
+      expect(result.isKnown).toBe(true);
+    });
+
+    test('decodes NotOwner (code 7)', () => {
+      const result = decodeSorobanError(7, 'names');
+      expect(result.code).toBe(7);
+      expect(result.name).toBe('NotOwner');
+      expect(result.isKnown).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Built-in: Stealth Announcer (no custom errors)
+  // -----------------------------------------------------------------------
+  describe('stealth-announcer', () => {
+    test('announcer registry exists but has no errors', () => {
+      const result = decodeSorobanError(1, 'announcer');
+      expect(result.isKnown).toBe(false);
+      expect(result.name).toBe('UnknownError');
+      expect(result.contractId).toBe('announcer');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cross-registry search (no contractId)
+  // -----------------------------------------------------------------------
+  describe('without contractId (cross-registry search)', () => {
+    test('finds error across all registries', () => {
+      // Code 6 is NameNotFound in the wraith-names registry
+      const result = decodeSorobanError(6);
+      expect(result.isKnown).toBe(true);
+      expect(result.name).toBe('NameNotFound');
+      expect(result.contractId).toBe('names');
+    });
+
+    test('finds code 1 - first registry match', () => {
+      const result = decodeSorobanError(1);
+      expect(result.isKnown).toBe(true);
+      // Code 1 exists in both registry (InvalidMetaAddressLength) and names (NameTaken)
+      // and sender (AlreadyInitialized). Should find one of them.
+      expect(['InvalidMetaAddressLength', 'NameTaken', 'AlreadyInitialized']).toContain(
+        result.name,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Unknown contract / error codes
+  // -----------------------------------------------------------------------
+  describe('unknown errors', () => {
+    test('returns fallback for unknown contractId', () => {
+      const result = decodeSorobanError(1, 'nonexistent-contract');
+      expect(result.isKnown).toBe(false);
+      expect(result.name).toBe('UnknownError');
+      expect(result.contractId).toBe('nonexistent-contract');
+      expect(result.suggestedFix).toBeTruthy();
+    });
+
+    test('returns fallback for unknown error code with known contract', () => {
+      // wraith-names only has codes 1-7
+      const result = decodeSorobanError(99, 'names');
+      expect(result.isKnown).toBe(false);
+      expect(result.name).toBe('UnknownError');
+      expect(result.contractId).toBe('names');
+      expect(result.suggestedFix).toBeTruthy();
+    });
+
+    test('returns fallback for unknown error code without contractId', () => {
+      const result = decodeSorobanError(9999);
+      expect(result.isKnown).toBe(false);
+      expect(result.name).toBe('UnknownError');
+      expect(result.contractId).toBeNull();
+      expect(result.description).toContain('9999');
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // All built-in error codes are unique per contract
+  // -----------------------------------------------------------------------
+  describe('error data integrity', () => {
+    test('all built-in errors have required fields', () => {
+      const contractIds = ['registry', 'sender', 'names'];
+
+      for (const contractId of contractIds) {
+        // Test a few known codes for each contract
+        if (contractId === 'registry') {
+          for (const code of [1, 2]) {
+            const result = decodeSorobanError(code, contractId);
+            expect(result.isKnown).toBe(true);
+            expect(result.name).toBeTruthy();
+            expect(result.description).toBeTruthy();
+            expect(result.code).toBe(code);
+          }
+        }
+        if (contractId === 'sender') {
+          for (const code of [1, 2, 3]) {
+            const result = decodeSorobanError(code, contractId);
+            expect(result.isKnown).toBe(true);
+            expect(result.name).toBeTruthy();
+            expect(result.description).toBeTruthy();
+          }
+        }
+        if (contractId === 'names') {
+          for (const code of [1, 2, 3, 4, 5, 6, 7]) {
+            const result = decodeSorobanError(code, contractId);
+            expect(result.isKnown).toBe(true);
+            expect(result.name).toBeTruthy();
+            expect(result.description).toBeTruthy();
+          }
+        }
+      }
+    });
+  });
+});
+
+describe('registerErrorRegistry', () => {
+  // Reset registries before each test by re-testing known behavior
+  // Since we can't easily reset, we test that registration works by using
+  // a unique contract ID that won't conflict with built-in ones
+
+  test('registers and decodes custom errors', () => {
+    const customRegistry: ErrorRegistry = {
+      contractId: 'my-custom-contract',
+      contractName: 'My Custom Contract',
+      errors: [
+        {
+          code: 1,
+          name: 'Unauthorized',
+          description: 'Caller is not authorized.',
+          suggestedFix: 'Use the authorized account.',
+        },
+        {
+          code: 2,
+          name: 'InsufficientBalance',
+          description: 'Not enough balance to complete the operation.',
+        },
+      ],
+    };
+
+    registerErrorRegistry(customRegistry);
+
+    const decoded = decodeSorobanError(1, 'my-custom-contract');
+    expect(decoded.isKnown).toBe(true);
+    expect(decoded.name).toBe('Unauthorized');
+    expect(decoded.description).toBe('Caller is not authorized.');
+    expect(decoded.suggestedFix).toBe('Use the authorized account.');
+    expect(decoded.contractId).toBe('my-custom-contract');
+
+    const decoded2 = decodeSorobanError(2, 'my-custom-contract');
+    expect(decoded2.isKnown).toBe(true);
+    expect(decoded2.name).toBe('InsufficientBalance');
+    // suggestedFix was not provided, should be null
+    expect(decoded2.suggestedFix).toBeNull();
+  });
+
+  test('custom registry is searchable without contractId', () => {
+    const decoded = decodeSorobanError(2);
+    // Should find InsufficientBalance from the custom registry
+    // (may find other codes too, but at least code 2 shouldn't be UnknownError)
+    expect(decoded.isKnown).toBe(true);
+  });
+
+  test('multiple contractId aliases for same errors', () => {
+    registerErrorRegistry({
+      contractId: 'alias-contract',
+      contractName: 'Alias Contract',
+      errors: [
+        {
+          code: 100,
+          name: 'CustomError',
+          description: 'A custom error.',
+        },
+      ],
+    });
+
+    const decoded = decodeSorobanError(100, 'alias-contract');
+    expect(decoded.isKnown).toBe(true);
+    expect(decoded.name).toBe('CustomError');
+  });
+});
+
+describe('deployed contract ID resolution', () => {
+  test('decodes errors by deployed Soroban contract ID for names', () => {
+    // The known testnet names contract ID
+    const namesContractId = 'CDEMB3MAE62ZOCCKZPTYSXR5CS5WVENPOU5MDVK4PNKTZXFVDC74AFBV';
+    const result = decodeSorobanError(6, namesContractId);
+    expect(result.isKnown).toBe(true);
+    expect(result.name).toBe('NameNotFound');
+  });
+
+  test('decodes errors by deployed Soroban contract ID for announcer', () => {
+    const announcerContractId = 'CCJLJ2QRBJAAKIG6ELNQVXLLWMKKWVN5O2FKWUETHZGMPAD4MHK7WVWL';
+    const result = decodeSorobanError(1, announcerContractId);
+    // Announcer has no custom errors, so it should be unknown
+    expect(result.isKnown).toBe(false);
+    expect(result.name).toBe('UnknownError');
+  });
+});

--- a/test/chains/stellar/scan.test.ts
+++ b/test/chains/stellar/scan.test.ts
@@ -10,6 +10,7 @@ import {
   checkStealthAddress,
   scanAnnouncements,
   scanAnnouncementsLegacySharedSecretTag,
+} from '../../../src/chains/stellar/scan';
 import { generateStealthAddress } from '../../../src/chains/stellar/stealth';
 import {
   checkStealthAddress,


### PR DESCRIPTION
Implements #83 — Stellar Soroban error decoder library.

## Changes

- **decodeSorobanError(errorCode, contractId?)** — decodes Soroban contract revert error codes into human-readable results with name, description, and suggested fixes
- **registerErrorRegistry()** — pluggable API for custom contract error registries
- **Built-in registries** for Stealth Announcer, Stealth Registry, Stealth Sender, and Wraith Names contracts
- **Fallback mechanism** for unknown errors or contracts
- **Deployment contract IDs** auto-registered as lookup aliases
- **24 unit tests** covering all error codes, cross-registry search, custom registries, and edge cases

Also fixes a pre-existing syntax error in test/chains/stellar/scan.test.ts where an import block was missing its closing brace.

Closes #83
