### PR TITLE
feat(sdk-vue): parity with sdk-react hook set (#128)

### DIFF
--- a/examples/stellar-vue-receive/index.html
+++ b/examples/stellar-vue-receive/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Wraith Stellar — Receive Stealth Payments (Vue)</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/stellar-vue-receive/package.json
+++ b/examples/stellar-vue-receive/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@wraith-protocol/example-stellar-vue-receive",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc --noEmit && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "vue": "^3.5.0",
+    "@wraith-protocol/sdk-vue": "workspace:*",
+    "@wraith-protocol/sdk": "workspace:*"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "vite": "^6.0.0",
+    "vue-tsc": "^2.0.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/stellar-vue-receive/src/App.vue
+++ b/examples/stellar-vue-receive/src/App.vue
@@ -1,0 +1,185 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useStealthKeys, useMetaAddress } from '@wraith-protocol/sdk-vue';
+import { bytesToHex } from '@wraith-protocol/sdk/chains/stellar';
+
+const input = ref('');
+const deriveError = ref<string | null>(null);
+
+const { keys, deriveKeys, generateAddress, loading, error } = useStealthKeys('stellar');
+
+const { encode, encoded, decoded, decode, detectChain } = useMetaAddress();
+
+function parseHex(hex: string): Uint8Array | null {
+  const cleaned = hex.replace(/^0x/i, '');
+  if (!/^[0-9a-fA-F]+$/.test(cleaned) || cleaned.length % 2 !== 0) return null;
+  const bytes = new Uint8Array(cleaned.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = Number.parseInt(cleaned.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+function copyToClipboard(text: string) {
+  navigator.clipboard.writeText(text);
+}
+
+function handleDerive() {
+  deriveError.value = null;
+  const trimmed = input.value.trim();
+  if (!trimmed) {
+    deriveError.value = 'Please enter a secret key.';
+    return;
+  }
+  const bytes = parseHex(trimmed);
+  if (!bytes) {
+    deriveError.value = 'Invalid hex string. Must be even-length hex.';
+    return;
+  }
+  if (bytes.length !== 64) {
+    deriveError.value = `Expected 64 bytes, got ${bytes.length}.`;
+    return;
+  }
+  try {
+    const k = deriveKeys(bytes) as {
+      spendingKey: Uint8Array;
+      spendingPubKey: Uint8Array;
+      viewingKey: Uint8Array;
+      viewingPubKey: Uint8Array;
+    };
+    generateAddress(k.spendingPubKey, k.viewingPubKey);
+    encode(k.spendingPubKey, k.viewingPubKey);
+  } catch (e) {
+    deriveError.value = e instanceof Error ? e.message : 'Key derivation failed.';
+  }
+}
+
+function safeHex(val: unknown): string {
+  if (val instanceof Uint8Array) return bytesToHex(val);
+  if (typeof val === 'string') return val;
+  return String(val);
+}
+
+const metaAddress = computed(() => encoded.value);
+const spendingKeyHex = computed(() =>
+  keys.value ? safeHex((keys.value as Record<string, unknown>).spendingKey) : '',
+);
+const viewingPubKeyHex = computed(() =>
+  keys.value ? safeHex((keys.value as Record<string, unknown>).viewingPubKey) : '',
+);
+
+const replacer = (_: string, v: unknown) => (v instanceof Uint8Array ? Array.from(v).join(',') : v);
+</script>
+
+<template>
+  <main style="max-width: 640px; margin: 40px auto; font-family: system-ui, sans-serif">
+    <h1>Wraith Stellar — Receive Stealth Payments (Vue)</h1>
+    <p>
+      Enter your 64-byte hex secret key to derive your stealth keys and meta-address. Share the
+      meta-address with senders.
+    </p>
+
+    <section style="margin: 24px 0">
+      <label for="secret" style="display: block; margin-bottom: 8px; font-weight: 600">
+        Secret Key (hex, 64 bytes)
+      </label>
+      <textarea
+        id="secret"
+        v-model="input"
+        rows="3"
+        style="width: 100%; font-family: monospace; padding: 8px"
+        placeholder="aa... (128 hex chars)"
+      />
+      <button
+        :disabled="loading"
+        @click="handleDerive"
+        style="margin-top: 8px; padding: 8px 24px; cursor: pointer"
+      >
+        {{ loading ? 'Deriving...' : 'Derive Stealth Keys' }}
+      </button>
+    </section>
+
+    <section v-if="deriveError || error" style="color: #c00; margin: 16px 0">
+      <strong>Error:</strong> {{ deriveError || error }}
+    </section>
+
+    <section
+      v-if="keys"
+      style="
+        background: #f5f5f5;
+        border: 1px solid #ddd;
+        border-radius: 8px;
+        padding: 16px;
+        margin: 16px 0;
+      "
+    >
+      <h2>Your Stealth Keys</h2>
+      <table style="width: 100%; border-collapse: collapse">
+        <tbody>
+          <tr>
+            <td style="padding: 6px 8px; font-weight: 500; white-space: nowrap">
+              Spending Secret Key
+            </td>
+            <td
+              style="
+                padding: 6px 8px;
+                font-family: monospace;
+                font-size: 13px;
+                word-break: break-all;
+              "
+            >
+              {{ spendingKeyHex }}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 6px 8px; font-weight: 500; white-space: nowrap">
+              Viewing Public Key
+            </td>
+            <td
+              style="
+                padding: 6px 8px;
+                font-family: monospace;
+                font-size: 13px;
+                word-break: break-all;
+              "
+            >
+              {{ viewingPubKeyHex }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div v-if="metaAddress" style="margin-top: 16px">
+        <strong>Stealth Meta-Address</strong>
+        <pre
+          style="
+            background: #fff;
+            border: 1px solid #ccc;
+            border-radius: 4px;
+            padding: 12px;
+            margin-top: 6px;
+            overflow: auto;
+            user-select: all;
+            cursor: pointer;
+          "
+          @click="copyToClipboard(metaAddress)"
+          title="Click to copy"
+          >{{ metaAddress }}</pre
+        >
+        <p style="font-size: 13px; color: #666">
+          Click the meta-address above to copy it. Share this with anyone who wants to send you
+          stealth payments.
+        </p>
+
+        <hr style="margin: 16px 0" />
+
+        <h3>Decoded Meta Address</h3>
+        <button @click="decode(metaAddress)">Decode</button>
+        <pre v-if="decoded" style="margin-top: 8px">{{ JSON.stringify(decoded, replacer, 2) }}</pre>
+        <p v-if="decoded" style="font-size: 13px; color: #666">
+          Chain: {{ detectChain(metaAddress) }}
+        </p>
+      </div>
+    </section>
+  </main>
+</template>

--- a/examples/stellar-vue-receive/src/main.ts
+++ b/examples/stellar-vue-receive/src/main.ts
@@ -1,0 +1,4 @@
+import { createApp } from 'vue';
+import App from './App.vue';
+
+createApp(App).mount('#app');

--- a/examples/stellar-vue-receive/tsconfig.json
+++ b/examples/stellar-vue-receive/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "skipLibCheck": true,
+    "paths": {
+      "@wraith-protocol/sdk": ["../../src"],
+      "@wraith-protocol/sdk-vue": ["../../packages/sdk-vue/src"]
+    }
+  },
+  "include": ["src"]
+}

--- a/examples/stellar-vue-receive/vite.config.ts
+++ b/examples/stellar-vue-receive/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
+
+export default defineConfig({
+  plugins: [vue()],
+});

--- a/packages/sdk-vue/src/composables/useActivity.ts
+++ b/packages/sdk-vue/src/composables/useActivity.ts
@@ -1,0 +1,113 @@
+import { ref, readonly } from 'vue';
+import {
+  scanAnnouncements as evmScan,
+  type Announcement as EvmAnnouncement,
+} from '@wraith-protocol/sdk/chains/evm';
+import { scanAnnouncements as stellarScan } from '@wraith-protocol/sdk/chains/stellar';
+import { scanAnnouncements as solanaScan } from '@wraith-protocol/sdk/chains/solana';
+import type { AnyStealthKeys } from './useStealthKeys';
+
+export type ActivityChain = 'evm' | 'stellar' | 'solana';
+
+export interface ActivityEvent {
+  id: string;
+  chain: ActivityChain;
+  type: 'incoming' | 'outgoing';
+  stealthAddress: string;
+  timestamp: number;
+  data: unknown;
+}
+
+export interface ScanActivityInput {
+  chain: ActivityChain;
+  announcements: unknown[];
+  keys: AnyStealthKeys;
+}
+
+export function useActivity() {
+  const scanning = ref(false);
+  const error = ref<string | null>(null);
+  const events = ref<ActivityEvent[]>([]);
+  const totalMatched = ref(0);
+
+  async function scanAnnouncements(
+    announcementsInput: ScanActivityInput[],
+  ): Promise<ActivityEvent[]> {
+    scanning.value = true;
+    error.value = null;
+    try {
+      const newEvents: ActivityEvent[] = [];
+      for (const input of announcementsInput) {
+        const { chain, announcements: anns, keys } = input;
+        if (!anns || anns.length === 0) continue;
+        let matched: { stealthAddress?: string }[];
+        switch (chain) {
+          case 'evm': {
+            const k = keys as unknown as Record<string, string>;
+            matched = evmScan(
+              anns as EvmAnnouncement[],
+              k.viewingKey as `0x${string}`,
+              k.spendingPubKey as `0x${string}`,
+              k.spendingKey as `0x${string}`,
+            ) as unknown as { stealthAddress?: string }[];
+            break;
+          }
+          case 'stellar': {
+            const k = keys as unknown as Record<string, unknown>;
+            matched = stellarScan(
+              anns as any[],
+              k.viewingKey as Uint8Array,
+              k.spendingPubKey as Uint8Array,
+              k.spendingScalar as bigint,
+            ) as unknown as { stealthAddress?: string }[];
+            break;
+          }
+          case 'solana': {
+            const k = keys as unknown as Record<string, unknown>;
+            matched = solanaScan(
+              anns as any[],
+              k.viewingKey as Uint8Array,
+              k.spendingPubKey as Uint8Array,
+              k.spendingScalar as bigint,
+            ) as unknown as { stealthAddress?: string }[];
+            break;
+          }
+        }
+        for (const m of matched) {
+          newEvents.push({
+            id: `${chain}-${newEvents.length}-${Date.now()}`,
+            chain,
+            type: 'incoming',
+            stealthAddress: m.stealthAddress ?? 'unknown',
+            timestamp: Date.now(),
+            data: m,
+          });
+        }
+      }
+      events.value = [...events.value, ...newEvents];
+      totalMatched.value += newEvents.length;
+      return newEvents;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Activity scan failed';
+      error.value = msg;
+      throw e;
+    } finally {
+      scanning.value = false;
+    }
+  }
+
+  function clear() {
+    events.value = [];
+    totalMatched.value = 0;
+    error.value = null;
+  }
+
+  return {
+    scanning: readonly(scanning),
+    error: readonly(error),
+    events: readonly(events),
+    totalMatched: readonly(totalMatched),
+    scanAnnouncements,
+    clear,
+  };
+}

--- a/packages/sdk-vue/src/composables/useMetaAddress.ts
+++ b/packages/sdk-vue/src/composables/useMetaAddress.ts
@@ -1,0 +1,7 @@
+import { useStealthMetaAddress } from './useStealthMetaAddress';
+
+export { useStealthMetaAddress };
+
+export function useMetaAddress() {
+  return useStealthMetaAddress();
+}

--- a/packages/sdk-vue/src/composables/useScanner.ts
+++ b/packages/sdk-vue/src/composables/useScanner.ts
@@ -1,0 +1,220 @@
+import { ref, readonly } from 'vue';
+import {
+  fetchAnnouncements as evmFetchAnnouncements,
+  scanAnnouncements as evmScanAnnouncements,
+  checkStealthAddress as evmCheckAddress,
+  type HexString,
+  type Announcement as EvmAnnouncement,
+  type MatchedAnnouncement as EvmMatchedAnnouncement,
+} from '@wraith-protocol/sdk/chains/evm';
+import {
+  fetchAnnouncementsStream as stellarFetchAnnouncementsStream,
+  scanAnnouncements as stellarScanAnnouncements,
+  checkStealthAddress as stellarCheckAddress,
+  type Announcement as StellarAnnouncement,
+  type MatchedAnnouncement as StellarMatchedAnnouncement,
+} from '@wraith-protocol/sdk/chains/stellar';
+import {
+  fetchAnnouncements as solanaFetchAnnouncements,
+  scanAnnouncements as solanaScanAnnouncements,
+  checkStealthAddress as solanaCheckAddress,
+  type Announcement as SolanaAnnouncement,
+  type MatchedAnnouncement as SolanaMatchedAnnouncement,
+} from '@wraith-protocol/sdk/chains/solana';
+import type { StealthChain, AnyStealthKeys } from './useStealthKeys';
+
+async function collectStream<T>(stream: AsyncGenerator<T>): Promise<T[]> {
+  const result: T[] = [];
+  for await (const item of stream) result.push(item);
+  return result;
+}
+
+export type AnyAnnouncement = EvmAnnouncement | StellarAnnouncement | SolanaAnnouncement;
+export type AnyMatchedAnnouncement =
+  | EvmMatchedAnnouncement
+  | StellarMatchedAnnouncement
+  | SolanaMatchedAnnouncement;
+
+export function useScanner(chain?: StealthChain) {
+  const activeChain = ref<StealthChain>(chain ?? 'stellar');
+  const announcements = ref<AnyAnnouncement[]>([]);
+  const matched = ref<AnyMatchedAnnouncement[]>([]);
+  const scanning = ref(false);
+  const error = ref<string | null>(null);
+
+  function setChain(c: StealthChain) {
+    activeChain.value = c;
+  }
+
+  async function fetchAnnouncementsList(
+    chainOrOpts?: string | { chain: string; url?: string },
+    url?: string,
+  ): Promise<AnyAnnouncement[]> {
+    scanning.value = true;
+    error.value = null;
+    try {
+      let list: AnyAnnouncement[];
+      switch (activeChain.value) {
+        case 'evm': {
+          const c = typeof chainOrOpts === 'string' ? chainOrOpts : (chainOrOpts as any)?.chain;
+          const u = typeof chainOrOpts === 'object' ? (chainOrOpts as any).url : url;
+          list = await evmFetchAnnouncements(c ?? activeChain.value, u);
+          break;
+        }
+        case 'stellar': {
+          const c = typeof chainOrOpts === 'string' ? chainOrOpts : undefined;
+          const u = typeof chainOrOpts === 'object' ? (chainOrOpts as any).url : url;
+          const stream = stellarFetchAnnouncementsStream(c, u);
+          list = await collectStream(stream);
+          break;
+        }
+        case 'solana': {
+          const c = typeof chainOrOpts === 'string' ? chainOrOpts : undefined;
+          const u = typeof chainOrOpts === 'object' ? (chainOrOpts as any).url : url;
+          list = await solanaFetchAnnouncements(c, u);
+          break;
+        }
+      }
+      announcements.value = list;
+      return list;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Failed to fetch announcements';
+      error.value = msg;
+      throw e;
+    } finally {
+      scanning.value = false;
+    }
+  }
+
+  function scanAnnouncements(
+    announcementsList: AnyAnnouncement[],
+    viewingKey: Uint8Array | HexString,
+    spendingPubKey: Uint8Array | HexString,
+    spendingKey: Uint8Array | HexString | bigint,
+  ): AnyMatchedAnnouncement[] {
+    scanning.value = true;
+    error.value = null;
+    try {
+      let result: AnyMatchedAnnouncement[];
+      switch (activeChain.value) {
+        case 'evm':
+          result = evmScanAnnouncements(
+            announcementsList as EvmAnnouncement[],
+            viewingKey as HexString,
+            spendingPubKey as HexString,
+            spendingKey as HexString,
+          );
+          break;
+        case 'stellar':
+          result = stellarScanAnnouncements(
+            announcementsList as StellarAnnouncement[],
+            viewingKey as Uint8Array,
+            spendingPubKey as Uint8Array,
+            spendingKey as bigint,
+          );
+          break;
+        case 'solana':
+          result = solanaScanAnnouncements(
+            announcementsList as SolanaAnnouncement[],
+            viewingKey as Uint8Array,
+            spendingPubKey as Uint8Array,
+            spendingKey as bigint,
+          );
+          break;
+      }
+      matched.value = result;
+      return result;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Scan failed';
+      error.value = msg;
+      throw e;
+    } finally {
+      scanning.value = false;
+    }
+  }
+
+  function checkAddress(
+    ephemeralPubKey: Uint8Array | HexString,
+    viewingKey: Uint8Array | HexString,
+    spendingPubKey: Uint8Array | HexString,
+    viewTag: number,
+  ) {
+    scanning.value = true;
+    error.value = null;
+    try {
+      switch (activeChain.value) {
+        case 'evm':
+          return evmCheckAddress(
+            ephemeralPubKey as HexString,
+            viewingKey as HexString,
+            spendingPubKey as HexString,
+            viewTag,
+          );
+        case 'stellar':
+          return stellarCheckAddress(
+            ephemeralPubKey as Uint8Array,
+            viewingKey as Uint8Array,
+            spendingPubKey as Uint8Array,
+            viewTag,
+          );
+        case 'solana':
+          return solanaCheckAddress(
+            ephemeralPubKey as Uint8Array,
+            viewingKey as Uint8Array,
+            spendingPubKey as Uint8Array,
+            viewTag,
+          );
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Address check failed';
+      error.value = msg;
+      throw e;
+    } finally {
+      scanning.value = false;
+    }
+  }
+
+  async function scanWithKeys(
+    keys: AnyStealthKeys,
+    chainOrUrl?: string,
+  ): Promise<AnyMatchedAnnouncement[]> {
+    await fetchAnnouncementsList(chainOrUrl);
+    if (announcements.value.length === 0) return [];
+    let spendKey: any;
+    switch (activeChain.value) {
+      case 'evm':
+        spendKey = (keys as any).spendingKey;
+        break;
+      case 'stellar':
+      case 'solana':
+        spendKey = (keys as any).spendingScalar;
+        break;
+    }
+    return scanAnnouncements(
+      announcements.value,
+      (keys as any).viewingKey,
+      (keys as any).spendingPubKey,
+      spendKey,
+    );
+  }
+
+  function clear() {
+    announcements.value = [];
+    matched.value = [];
+    error.value = null;
+  }
+
+  return {
+    announcements: readonly(announcements),
+    matched: readonly(matched),
+    scanning: readonly(scanning),
+    error: readonly(error),
+    chain: readonly(activeChain),
+    setChain,
+    fetchAnnouncements: fetchAnnouncementsList,
+    scanAnnouncements,
+    checkAddress,
+    scanWithKeys,
+    clear,
+  };
+}

--- a/packages/sdk-vue/src/composables/useStealthKeys.ts
+++ b/packages/sdk-vue/src/composables/useStealthKeys.ts
@@ -1,0 +1,207 @@
+import { ref, readonly } from 'vue';
+import {
+  deriveStealthKeys as evmDeriveKeys,
+  generateStealthAddress as evmGenerateAddress,
+  checkStealthAddress as evmCheckAddress,
+  deriveStealthPrivateKey,
+  type HexString,
+  type StealthKeys as EvmStealthKeys,
+  type GeneratedStealthAddress as EvmGeneratedAddress,
+} from '@wraith-protocol/sdk/chains/evm';
+import {
+  deriveStealthKeys as stellarDeriveKeys,
+  generateStealthAddress as stellarGenerateAddress,
+  checkStealthAddress as stellarCheckAddress,
+  deriveStealthPrivateScalar,
+  type StealthKeys as StellarStealthKeys,
+  type GeneratedStealthAddress as StellarGeneratedAddress,
+} from '@wraith-protocol/sdk/chains/stellar';
+import {
+  deriveStealthKeys as solanaDeriveKeys,
+  generateStealthAddress as solanaGenerateAddress,
+  checkStealthAddress as solanaCheckAddress,
+  deriveStealthPrivateScalar as solanaDerivePrivateScalar,
+  type StealthKeys as SolanaStealthKeys,
+  type GeneratedStealthAddress as SolanaGeneratedAddress,
+} from '@wraith-protocol/sdk/chains/solana';
+
+export type StealthChain = 'evm' | 'stellar' | 'solana';
+
+export type AnyStealthKeys = EvmStealthKeys | StellarStealthKeys | SolanaStealthKeys;
+export type AnyGeneratedStealthAddress =
+  | EvmGeneratedAddress
+  | StellarGeneratedAddress
+  | SolanaGeneratedAddress;
+
+export function useStealthKeys(chain?: StealthChain) {
+  const activeChain = ref<StealthChain>(chain ?? 'stellar');
+  const keys = ref<AnyStealthKeys | null>(null);
+  const stealthAddress = ref<AnyGeneratedStealthAddress | null>(null);
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  function setChain(c: StealthChain) {
+    activeChain.value = c;
+  }
+
+  function deriveKeys(signature: Uint8Array | HexString): AnyStealthKeys {
+    loading.value = true;
+    error.value = null;
+    try {
+      let k: AnyStealthKeys;
+      switch (activeChain.value) {
+        case 'evm':
+          k = evmDeriveKeys(signature as HexString);
+          break;
+        case 'stellar':
+          k = stellarDeriveKeys(signature as Uint8Array);
+          break;
+        case 'solana':
+          k = solanaDeriveKeys(signature as Uint8Array);
+          break;
+      }
+      keys.value = k;
+      return k;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Key derivation failed';
+      error.value = msg;
+      throw e;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  function generateAddress(
+    spendingPubKey: Uint8Array | HexString,
+    viewingPubKey: Uint8Array | HexString,
+    ephemeralSeed?: Uint8Array | HexString,
+  ): AnyGeneratedStealthAddress {
+    loading.value = true;
+    error.value = null;
+    try {
+      let addr: AnyGeneratedStealthAddress;
+      switch (activeChain.value) {
+        case 'evm':
+          addr = evmGenerateAddress(
+            spendingPubKey as HexString,
+            viewingPubKey as HexString,
+            ephemeralSeed as HexString | undefined,
+          );
+          break;
+        case 'stellar':
+          addr = stellarGenerateAddress(
+            spendingPubKey as Uint8Array,
+            viewingPubKey as Uint8Array,
+            ephemeralSeed as Uint8Array | undefined,
+          );
+          break;
+        case 'solana':
+          addr = solanaGenerateAddress(
+            spendingPubKey as Uint8Array,
+            viewingPubKey as Uint8Array,
+            ephemeralSeed as Uint8Array | undefined,
+          );
+          break;
+      }
+      stealthAddress.value = addr;
+      return addr;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Address generation failed';
+      error.value = msg;
+      throw e;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  function checkAddress(
+    ephemeralPubKey: Uint8Array | HexString,
+    viewingKey: Uint8Array | HexString,
+    spendingPubKey: Uint8Array | HexString,
+    viewTag: number,
+  ) {
+    loading.value = true;
+    error.value = null;
+    try {
+      switch (activeChain.value) {
+        case 'evm':
+          return evmCheckAddress(
+            ephemeralPubKey as HexString,
+            viewingKey as HexString,
+            spendingPubKey as HexString,
+            viewTag,
+          );
+        case 'stellar':
+          return stellarCheckAddress(
+            ephemeralPubKey as Uint8Array,
+            viewingKey as Uint8Array,
+            spendingPubKey as Uint8Array,
+            viewTag,
+          );
+        case 'solana':
+          return solanaCheckAddress(
+            ephemeralPubKey as Uint8Array,
+            viewingKey as Uint8Array,
+            spendingPubKey as Uint8Array,
+            viewTag,
+          );
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Address check failed';
+      error.value = msg;
+      throw e;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  function derivePrivateKey(
+    spendingKey: Uint8Array | HexString | bigint,
+    ephemeralPubKey: Uint8Array | HexString,
+    viewingKey: Uint8Array | HexString,
+  ): HexString | bigint {
+    loading.value = true;
+    error.value = null;
+    try {
+      switch (activeChain.value) {
+        case 'evm':
+          return deriveStealthPrivateKey(
+            spendingKey as HexString,
+            ephemeralPubKey as HexString,
+            viewingKey as HexString,
+          );
+        case 'stellar':
+          return deriveStealthPrivateScalar(
+            spendingKey as bigint,
+            viewingKey as Uint8Array,
+            ephemeralPubKey as Uint8Array,
+          );
+        case 'solana':
+          return solanaDerivePrivateScalar(
+            spendingKey as bigint,
+            viewingKey as Uint8Array,
+            ephemeralPubKey as Uint8Array,
+          );
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Private key derivation failed';
+      error.value = msg;
+      throw e;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  return {
+    keys: readonly(keys),
+    stealthAddress: readonly(stealthAddress),
+    loading: readonly(loading),
+    error: readonly(error),
+    chain: readonly(activeChain),
+    setChain,
+    deriveKeys,
+    generateAddress,
+    checkAddress,
+    derivePrivateKey,
+  };
+}

--- a/packages/sdk-vue/src/composables/useStellarStealthKeys.ts
+++ b/packages/sdk-vue/src/composables/useStellarStealthKeys.ts
@@ -7,13 +7,19 @@ import {
   deriveStealthPrivateScalar,
   encodeStealthMetaAddress,
   decodeStealthMetaAddress,
-  fetchAnnouncements,
+  fetchAnnouncementsStream,
   type StealthKeys,
   type GeneratedStealthAddress,
   type Announcement,
   type MatchedAnnouncement,
   type StealthMetaAddress,
 } from '@wraith-protocol/sdk/chains/stellar';
+
+async function collectAnnouncements(stream: AsyncGenerator<Announcement>): Promise<Announcement[]> {
+  const result: Announcement[] = [];
+  for await (const ann of stream) result.push(ann);
+  return result;
+}
 
 export function useStellarStealthKeys() {
   const keys = ref<StealthKeys | null>(null);
@@ -130,7 +136,8 @@ export function useStellarStealthKeys() {
     loading.value = true;
     error.value = null;
     try {
-      const list = await fetchAnnouncements(chain, sorobanUrl);
+      const stream = fetchAnnouncementsStream(chain, sorobanUrl);
+      const list = await collectAnnouncements(stream);
       announcements.value = list;
       return list;
     } catch (e) {

--- a/packages/sdk-vue/src/index.ts
+++ b/packages/sdk-vue/src/index.ts
@@ -4,3 +4,14 @@ export { useEvmStealthKeys } from './composables/useEvmStealthKeys';
 export { useSolanaStealthKeys } from './composables/useSolanaStealthKeys';
 export { useStealthMetaAddress } from './composables/useStealthMetaAddress';
 export type { ChainType } from './composables/useStealthMetaAddress';
+export { useStealthKeys } from './composables/useStealthKeys';
+export type {
+  StealthChain,
+  AnyStealthKeys,
+  AnyGeneratedStealthAddress,
+} from './composables/useStealthKeys';
+export { useScanner } from './composables/useScanner';
+export type { AnyAnnouncement, AnyMatchedAnnouncement } from './composables/useScanner';
+export { useMetaAddress } from './composables/useMetaAddress';
+export { useActivity } from './composables/useActivity';
+export type { ActivityEvent } from './composables/useActivity';

--- a/packages/sdk-vue/test/useActivity.test.ts
+++ b/packages/sdk-vue/test/useActivity.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useActivity } from '../src/composables/useActivity';
+
+const mockEvmKeys = vi.hoisted(() => ({
+  spendingKey: '0x' + 'ab'.repeat(32),
+  viewingKey: '0x' + 'cd'.repeat(32),
+  spendingPubKey: '0x' + 'ef'.repeat(33),
+  viewingPubKey: '0x' + '01'.repeat(33),
+}));
+
+const mockStellarKeys = vi.hoisted(() => ({
+  spendingKey: new Uint8Array(32),
+  spendingScalar: 1n,
+  viewingKey: new Uint8Array(32),
+  viewingScalar: 2n,
+  spendingPubKey: new Uint8Array(32),
+  viewingPubKey: new Uint8Array(32),
+}));
+
+const mockEvmMatched = vi.hoisted(() => [
+  {
+    isMatch: true,
+    stealthAddress: '0x' + '02'.repeat(20),
+    viewTag: 42,
+  },
+]);
+
+const mockStellarMatched = vi.hoisted(() => [
+  {
+    isMatch: true,
+    stealthAddress: 'GABCDEF1234567890',
+    hashScalar: 3n,
+    stealthPubKeyBytes: new Uint8Array(32),
+  },
+]);
+
+vi.mock('@wraith-protocol/sdk/chains/evm', () => ({
+  scanAnnouncements: vi.fn().mockReturnValue(mockEvmMatched),
+}));
+
+vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
+  scanAnnouncements: vi.fn().mockReturnValue(mockStellarMatched),
+}));
+
+vi.mock('@wraith-protocol/sdk/chains/solana', () => ({
+  scanAnnouncements: vi.fn().mockReturnValue([
+    {
+      isMatch: true,
+      stealthAddress: 'FAKESOLANA...',
+      hashScalar: 3n,
+      stealthPubKeyBytes: new Uint8Array(32),
+    },
+  ]),
+}));
+
+describe('useActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initial state is empty', () => {
+    const composable = useActivity();
+    expect(composable.scanning.value).toBe(false);
+    expect(composable.error.value).toBeNull();
+    expect(composable.events.value).toEqual([]);
+    expect(composable.totalMatched.value).toBe(0);
+  });
+
+  it('scans EVM announcements and creates events', async () => {
+    const composable = useActivity();
+    const result = await composable.scanAnnouncements([
+      {
+        chain: 'evm',
+        announcements: [
+          {
+            schemeId: 1n,
+            stealthAddress: '0x' + '02'.repeat(20),
+            caller: '0x' + 'aa'.repeat(20),
+            ephemeralPubKey: '0x' + '03'.repeat(33),
+            metadata: '0x',
+          },
+        ],
+        keys: mockEvmKeys as any,
+      },
+    ]);
+    expect(result.length).toBe(1);
+    expect(result[0].chain).toBe('evm');
+    expect(result[0].type).toBe('incoming');
+    expect(result[0].stealthAddress).toBe('0x' + '02'.repeat(20));
+    expect(composable.events.value.length).toBe(1);
+    expect(composable.totalMatched.value).toBe(1);
+  });
+
+  it('scans Stellar announcements and creates events', async () => {
+    const composable = useActivity();
+    const result = await composable.scanAnnouncements([
+      {
+        chain: 'stellar',
+        announcements: [
+          {
+            schemeId: 1,
+            stealthAddress: 'GABCDEF1234567890',
+            caller: 'GDEADBEEF',
+            ephemeralPubKey: new Uint8Array(32),
+            metadata: new Uint8Array(0),
+          },
+        ],
+        keys: mockStellarKeys as any,
+      },
+    ]);
+    expect(result.length).toBe(1);
+    expect(result[0].chain).toBe('stellar');
+    expect(result[0].stealthAddress).toBe('GABCDEF1234567890');
+    expect(composable.events.value.length).toBe(1);
+    expect(composable.totalMatched.value).toBe(1);
+  });
+
+  it('scans multiple chains', async () => {
+    const composable = useActivity();
+    await composable.scanAnnouncements([
+      {
+        chain: 'evm',
+        announcements: [],
+        keys: mockEvmKeys as any,
+      },
+      {
+        chain: 'stellar',
+        announcements: [
+          {
+            schemeId: 1,
+            stealthAddress: 'GABCDEF1234567890',
+            caller: 'GDEADBEEF',
+            ephemeralPubKey: new Uint8Array(32),
+            metadata: new Uint8Array(0),
+          },
+        ],
+        keys: mockStellarKeys as any,
+      },
+    ]);
+    expect(composable.events.value.length).toBe(1);
+    expect(composable.totalMatched.value).toBe(1);
+  });
+
+  it('accumulates events across multiple scans', async () => {
+    const composable = useActivity();
+    await composable.scanAnnouncements([
+      {
+        chain: 'evm',
+        announcements: [
+          {
+            schemeId: 1n,
+            stealthAddress: '0x' + '02'.repeat(20),
+            caller: '0x' + 'aa'.repeat(20),
+            ephemeralPubKey: '0x' + '03'.repeat(33),
+            metadata: '0x',
+          },
+        ],
+        keys: mockEvmKeys as any,
+      },
+    ]);
+    await composable.scanAnnouncements([
+      {
+        chain: 'stellar',
+        announcements: [
+          {
+            schemeId: 1,
+            stealthAddress: 'GABCDEF1234567890',
+            caller: 'GDEADBEEF',
+            ephemeralPubKey: new Uint8Array(32),
+            metadata: new Uint8Array(0),
+          },
+        ],
+        keys: mockStellarKeys as any,
+      },
+    ]);
+    expect(composable.events.value.length).toBe(2);
+    expect(composable.totalMatched.value).toBe(2);
+  });
+
+  it('clear resets state', async () => {
+    const composable = useActivity();
+    await composable.scanAnnouncements([
+      {
+        chain: 'evm',
+        announcements: [
+          {
+            schemeId: 1n,
+            stealthAddress: '0x' + '02'.repeat(20),
+            caller: '0x' + 'aa'.repeat(20),
+            ephemeralPubKey: '0x' + '03'.repeat(33),
+            metadata: '0x',
+          },
+        ],
+        keys: mockEvmKeys as any,
+      },
+    ]);
+    expect(composable.totalMatched.value).toBe(1);
+    composable.clear();
+    expect(composable.events.value.length).toBe(0);
+    expect(composable.totalMatched.value).toBe(0);
+    expect(composable.error.value).toBeNull();
+  });
+
+  it('handles empty announcements for all chains', async () => {
+    const composable = useActivity();
+    const result = await composable.scanAnnouncements([
+      { chain: 'evm', announcements: [], keys: mockEvmKeys as any },
+      { chain: 'stellar', announcements: [], keys: mockStellarKeys as any },
+    ]);
+    expect(result.length).toBe(0);
+    expect(composable.totalMatched.value).toBe(0);
+  });
+});

--- a/packages/sdk-vue/test/useMetaAddress.test.ts
+++ b/packages/sdk-vue/test/useMetaAddress.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useMetaAddress } from '../src/composables/useMetaAddress';
+
+const evmEncoded = vi.hoisted(() => 'st:eth:0x' + 'ab'.repeat(66));
+const stellarEncoded = vi.hoisted(() => 'st:xlm:' + 'cd'.repeat(64));
+const solanaEncoded = vi.hoisted(() => 'st:sol:' + 'ef'.repeat(64));
+
+vi.mock('@wraith-protocol/sdk/chains/evm', () => ({
+  encodeStealthMetaAddress: vi.fn().mockReturnValue(evmEncoded),
+  decodeStealthMetaAddress: vi.fn().mockReturnValue({
+    prefix: 'st:eth:0x',
+    spendingPubKey: '0x' + '01'.repeat(33),
+    viewingPubKey: '0x' + '02'.repeat(33),
+  }),
+  META_ADDRESS_PREFIX: 'st:eth:0x',
+}));
+
+vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
+  encodeStealthMetaAddress: vi.fn().mockReturnValue(stellarEncoded),
+  decodeStealthMetaAddress: vi.fn().mockReturnValue({
+    prefix: 'st:xlm:',
+    spendingPubKey: new Uint8Array(32),
+    viewingPubKey: new Uint8Array(32),
+  }),
+  META_ADDRESS_PREFIX: 'st:xlm:',
+}));
+
+vi.mock('@wraith-protocol/sdk/chains/solana', () => ({
+  encodeStealthMetaAddress: vi.fn().mockReturnValue(solanaEncoded),
+  decodeStealthMetaAddress: vi.fn().mockReturnValue({
+    prefix: 'st:sol:',
+    spendingPubKey: new Uint8Array(32),
+    viewingPubKey: new Uint8Array(32),
+  }),
+  META_ADDRESS_PREFIX: 'st:sol:',
+}));
+
+describe('useMetaAddress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('encodes EVM meta address', () => {
+    const composable = useMetaAddress();
+    const result = composable.encode('0x' + '01'.repeat(33), '0x' + '02'.repeat(33), 'evm');
+    expect(result).toBe(evmEncoded);
+    expect(composable.encoded.value).toBe(evmEncoded);
+    expect(composable.chain.value).toBe('evm');
+  });
+
+  it('encodes Stellar meta address', () => {
+    const composable = useMetaAddress();
+    const result = composable.encode(new Uint8Array(32), new Uint8Array(32), 'stellar');
+    expect(result).toBe(stellarEncoded);
+    expect(composable.chain.value).toBe('stellar');
+  });
+
+  it('encodes Solana meta address', () => {
+    const composable = useMetaAddress();
+    const result = composable.encode(new Uint8Array(32), new Uint8Array(32), 'solana');
+    expect(result).toBe(solanaEncoded);
+    expect(composable.chain.value).toBe('solana');
+  });
+
+  it('decodes EVM meta address', () => {
+    const composable = useMetaAddress();
+    const result = composable.decode(evmEncoded);
+    expect(result.prefix).toBe('st:eth:0x');
+    expect(composable.chain.value).toBe('evm');
+  });
+
+  it('detects correct chain from prefix', () => {
+    const composable = useMetaAddress();
+    expect(composable.detectChain(evmEncoded)).toBe('evm');
+    expect(composable.detectChain(stellarEncoded)).toBe('stellar');
+    expect(composable.detectChain(solanaEncoded)).toBe('solana');
+  });
+
+  it('gets correct prefix for each chain', () => {
+    const composable = useMetaAddress();
+    expect(composable.getPrefix('evm')).toBe('st:eth:0x');
+    expect(composable.getPrefix('stellar')).toBe('st:xlm:');
+    expect(composable.getPrefix('solana')).toBe('st:sol:');
+  });
+
+  it('throws for unknown prefix', () => {
+    const composable = useMetaAddress();
+    expect(() => composable.detectChain('unknown:prefix:abc')).toThrow(
+      'Unknown meta address prefix',
+    );
+  });
+
+  it('setChain changes chain', () => {
+    const composable = useMetaAddress();
+    composable.setChain('stellar');
+    expect(composable.chain.value).toBe('stellar');
+  });
+
+  it('decode updates encoded ref on decode', () => {
+    const composable = useMetaAddress();
+    composable.decode(evmEncoded);
+    expect(composable.decoded.value).toBeTruthy();
+    expect(composable.chain.value).toBe('evm');
+  });
+});

--- a/packages/sdk-vue/test/useScanner.test.ts
+++ b/packages/sdk-vue/test/useScanner.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useScanner } from '../src/composables/useScanner';
+
+const mockEvmKeys = vi.hoisted(() => ({
+  spendingKey: '0x' + 'ab'.repeat(32),
+  viewingKey: '0x' + 'cd'.repeat(32),
+  spendingPubKey: '0x' + 'ef'.repeat(33),
+  viewingPubKey: '0x' + '01'.repeat(33),
+}));
+
+const mockStellarKeys = vi.hoisted(() => ({
+  spendingKey: new Uint8Array(32),
+  spendingScalar: 1n,
+  viewingKey: new Uint8Array(32),
+  viewingScalar: 2n,
+  spendingPubKey: new Uint8Array(32),
+  viewingPubKey: new Uint8Array(32),
+}));
+
+const mockEvmAnnouncements = vi.hoisted(() => [
+  {
+    schemeId: 1n,
+    stealthAddress: '0x' + '02'.repeat(20),
+    caller: '0x' + 'aa'.repeat(20),
+    ephemeralPubKey: '0x' + '03'.repeat(33),
+    metadata: '0x',
+  },
+]);
+
+const mockStellarAnnouncements = vi.hoisted(() => [
+  {
+    schemeId: 1,
+    stealthAddress: 'GABCDEF1234567890',
+    caller: 'GDEADBEEF',
+    ephemeralPubKey: new Uint8Array(32),
+    metadata: new Uint8Array(0),
+  },
+]);
+
+const mockEvmMatched = vi.hoisted(() => [
+  {
+    isMatch: true,
+    stealthAddress: '0x' + '02'.repeat(20),
+    viewTag: 42,
+  },
+]);
+
+const mockStellarMatched = vi.hoisted(() => [
+  {
+    isMatch: true,
+    stealthAddress: 'GABCDEF1234567890',
+    hashScalar: 3n,
+    stealthPubKeyBytes: new Uint8Array(32),
+  },
+]);
+
+vi.mock('@wraith-protocol/sdk/chains/evm', () => ({
+  fetchAnnouncements: vi.fn().mockResolvedValue(mockEvmAnnouncements),
+  scanAnnouncements: vi.fn().mockReturnValue(mockEvmMatched),
+  checkStealthAddress: vi.fn().mockReturnValue({
+    isMatch: true,
+    stealthAddress: '0x' + '02'.repeat(20),
+  }),
+}));
+
+const mockStellarStreamFactory = vi.hoisted(() => {
+  const announcements = [
+    {
+      schemeId: 1,
+      stealthAddress: 'GABCDEF1234567890',
+      caller: 'GDEADBEEF',
+      ephemeralPubKey: new Uint8Array(32),
+      metadata: new Uint8Array(0),
+    },
+  ];
+  return function createStream() {
+    async function* gen() {
+      for (const ann of announcements) yield ann;
+    }
+    return gen();
+  };
+});
+
+vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
+  fetchAnnouncementsStream: vi.fn().mockImplementation(() => mockStellarStreamFactory()),
+  scanAnnouncements: vi.fn().mockReturnValue(mockStellarMatched),
+  checkStealthAddress: vi.fn().mockReturnValue({
+    isMatch: true,
+    stealthAddress: 'GABCDEF1234567890',
+    hashScalar: 3n,
+    stealthPubKeyBytes: new Uint8Array(32),
+  }),
+}));
+
+vi.mock('@wraith-protocol/sdk/chains/solana', () => ({
+  fetchAnnouncements: vi.fn().mockResolvedValue([
+    {
+      schemeId: 1,
+      stealthAddress: 'FAKESOLANA...',
+      caller: 'FAKECALLER...',
+      ephemeralPubKey: 'ab'.repeat(32),
+      metadata: '',
+    },
+  ]),
+  scanAnnouncements: vi.fn().mockReturnValue([
+    {
+      isMatch: true,
+      stealthAddress: 'FAKESOLANA...',
+      hashScalar: 3n,
+      stealthPubKeyBytes: new Uint8Array(32),
+    },
+  ]),
+  checkStealthAddress: vi.fn().mockReturnValue({
+    isMatch: true,
+    stealthAddress: 'FAKESOLANA...',
+  }),
+}));
+
+describe('useScanner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to stellar chain', () => {
+    const composable = useScanner();
+    expect(composable.chain.value).toBe('stellar');
+  });
+
+  it('accepts chain parameter', () => {
+    const evm = useScanner('evm');
+    expect(evm.chain.value).toBe('evm');
+    const stellar = useScanner('stellar');
+    expect(stellar.chain.value).toBe('stellar');
+  });
+
+  it('setChain changes active chain', () => {
+    const composable = useScanner('evm');
+    composable.setChain('stellar');
+    expect(composable.chain.value).toBe('stellar');
+  });
+
+  it('fetches EVM announcements', async () => {
+    const composable = useScanner('evm');
+    const result = await composable.fetchAnnouncements('horizen');
+    expect(result).toEqual(mockEvmAnnouncements);
+    expect(composable.announcements.value).toEqual(mockEvmAnnouncements);
+  });
+
+  it('fetches Stellar announcements', async () => {
+    const composable = useScanner('stellar');
+    const result = await composable.fetchAnnouncements();
+    expect(result).toEqual(mockStellarAnnouncements);
+    expect(composable.announcements.value).toEqual(mockStellarAnnouncements);
+  });
+
+  it('scans EVM announcements', () => {
+    const composable = useScanner('evm');
+    const result = composable.scanAnnouncements(
+      mockEvmAnnouncements,
+      '0x' + 'cd'.repeat(32),
+      '0x' + 'ef'.repeat(33),
+      '0x' + 'ab'.repeat(32),
+    );
+    expect(result).toEqual(mockEvmMatched);
+    expect(composable.matched.value).toEqual(mockEvmMatched);
+  });
+
+  it('scans Stellar announcements', () => {
+    const composable = useScanner('stellar');
+    const result = composable.scanAnnouncements(
+      mockStellarAnnouncements,
+      new Uint8Array(32),
+      new Uint8Array(32),
+      1n,
+    );
+    expect(result).toEqual(mockStellarMatched);
+    expect(composable.matched.value).toEqual(mockStellarMatched);
+  });
+
+  it('checks EVM stealth address', () => {
+    const composable = useScanner('evm');
+    const result = composable.checkAddress(
+      '0x' + '03'.repeat(33),
+      '0x' + 'cd'.repeat(32),
+      '0x' + 'ef'.repeat(33),
+      42,
+    );
+    expect(result.isMatch).toBe(true);
+  });
+
+  it('checks Stellar stealth address', () => {
+    const composable = useScanner('stellar');
+    const result = composable.checkAddress(
+      new Uint8Array(32),
+      new Uint8Array(32),
+      new Uint8Array(32),
+      42,
+    );
+    expect(result.isMatch).toBe(true);
+  });
+
+  it('scanWithKeys fetches and scans EVM', async () => {
+    const composable = useScanner('evm');
+    const result = await composable.scanWithKeys(mockEvmKeys as any);
+    expect(result).toEqual(mockEvmMatched);
+    expect(composable.matched.value).toEqual(mockEvmMatched);
+  });
+
+  it('scanWithKeys fetches and scans Stellar', async () => {
+    const composable = useScanner('stellar');
+    const result = await composable.scanWithKeys(mockStellarKeys as any);
+    expect(result).toEqual(mockStellarMatched);
+    expect(composable.matched.value).toEqual(mockStellarMatched);
+  });
+
+  it('clear resets state', () => {
+    const composable = useScanner('evm');
+    composable.scanAnnouncements(
+      mockEvmAnnouncements,
+      '0x' + 'cd'.repeat(32),
+      '0x' + 'ef'.repeat(33),
+      '0x' + 'ab'.repeat(32),
+    );
+    expect(composable.matched.value.length).toBe(1);
+    composable.clear();
+    expect(composable.matched.value.length).toBe(0);
+    expect(composable.announcements.value.length).toBe(0);
+    expect(composable.error.value).toBeNull();
+  });
+
+  it('initial state', () => {
+    const composable = useScanner('stellar');
+    expect(composable.announcements.value).toEqual([]);
+    expect(composable.matched.value).toEqual([]);
+    expect(composable.scanning.value).toBe(false);
+    expect(composable.error.value).toBeNull();
+  });
+});

--- a/packages/sdk-vue/test/useStealthKeys.test.ts
+++ b/packages/sdk-vue/test/useStealthKeys.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useStealthKeys } from '../src/composables/useStealthKeys';
+
+const mockEvmKeys = vi.hoisted(() => ({
+  spendingKey: '0x' + 'ab'.repeat(32),
+  viewingKey: '0x' + 'cd'.repeat(32),
+  spendingPubKey: '0x' + 'ef'.repeat(33),
+  viewingPubKey: '0x' + '01'.repeat(33),
+}));
+
+const mockEvmAddress = vi.hoisted(() => ({
+  stealthAddress: '0x' + '02'.repeat(20),
+  ephemeralPubKey: '0x' + '03'.repeat(33),
+  viewTag: 42,
+}));
+
+const mockStellarKeys = vi.hoisted(() => ({
+  spendingKey: new Uint8Array(32),
+  spendingScalar: 1n,
+  viewingKey: new Uint8Array(32),
+  viewingScalar: 2n,
+  spendingPubKey: new Uint8Array(32),
+  viewingPubKey: new Uint8Array(32),
+}));
+
+const mockStellarAddress = vi.hoisted(() => ({
+  stealthAddress: 'GABCDEF1234567890',
+  ephemeralPubKey: new Uint8Array(32),
+  viewTag: 42,
+}));
+
+vi.mock('@wraith-protocol/sdk/chains/evm', () => ({
+  deriveStealthKeys: vi.fn().mockReturnValue(mockEvmKeys),
+  generateStealthAddress: vi.fn().mockReturnValue(mockEvmAddress),
+  checkStealthAddress: vi.fn().mockReturnValue({
+    isMatch: true,
+    stealthAddress: '0x' + '02'.repeat(20),
+  }),
+  deriveStealthPrivateKey: vi.fn().mockReturnValue('0x' + '04'.repeat(32)),
+}));
+
+vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
+  deriveStealthKeys: vi.fn().mockReturnValue(mockStellarKeys),
+  generateStealthAddress: vi.fn().mockReturnValue(mockStellarAddress),
+  checkStealthAddress: vi.fn().mockReturnValue({
+    isMatch: true,
+    stealthAddress: 'GABCDEF1234567890',
+    hashScalar: 3n,
+    stealthPubKeyBytes: new Uint8Array(32),
+  }),
+  deriveStealthPrivateScalar: vi.fn().mockReturnValue(3n),
+}));
+
+vi.mock('@wraith-protocol/sdk/chains/solana', () => ({
+  deriveStealthKeys: vi.fn().mockReturnValue(mockStellarKeys),
+  generateStealthAddress: vi.fn().mockReturnValue({
+    stealthAddress: 'FAKESOLANA...',
+    ephemeralPubKey: new Uint8Array(32),
+    viewTag: 42,
+  }),
+  checkStealthAddress: vi.fn().mockReturnValue({
+    isMatch: true,
+    stealthAddress: 'FAKESOLANA...',
+    hashScalar: 3n,
+    stealthPubKeyBytes: new Uint8Array(32),
+  }),
+  deriveStealthPrivateScalar: vi.fn().mockReturnValue(3n),
+}));
+
+describe('useStealthKeys', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('defaults to stellar chain', () => {
+    const composable = useStealthKeys();
+    expect(composable.chain.value).toBe('stellar');
+  });
+
+  it('accepts chain parameter', () => {
+    const evm = useStealthKeys('evm');
+    expect(evm.chain.value).toBe('evm');
+    const stellar = useStealthKeys('stellar');
+    expect(stellar.chain.value).toBe('stellar');
+    const solana = useStealthKeys('solana');
+    expect(solana.chain.value).toBe('solana');
+  });
+
+  it('derives EVM keys from signature', () => {
+    const composable = useStealthKeys('evm');
+    const result = composable.deriveKeys('0x' + 'ff'.repeat(65));
+    expect(result).toEqual(mockEvmKeys);
+    expect(composable.keys.value).toEqual(mockEvmKeys);
+  });
+
+  it('derives Stellar keys from signature', () => {
+    const composable = useStealthKeys('stellar');
+    const sig = new Uint8Array(64);
+    const result = composable.deriveKeys(sig);
+    expect(result).toEqual(mockStellarKeys);
+    expect(composable.keys.value).toEqual(mockStellarKeys);
+  });
+
+  it('derives Solana keys from signature', () => {
+    const composable = useStealthKeys('solana');
+    const sig = new Uint8Array(64);
+    const result = composable.deriveKeys(sig);
+    expect(result).toEqual(mockStellarKeys);
+    expect(composable.keys.value).toEqual(mockStellarKeys);
+  });
+
+  it('generates EVM stealth address', () => {
+    const composable = useStealthKeys('evm');
+    const result = composable.generateAddress('0x' + 'ef'.repeat(33), '0x' + '01'.repeat(33));
+    expect(result).toEqual(mockEvmAddress);
+    expect(composable.stealthAddress.value).toEqual(mockEvmAddress);
+  });
+
+  it('generates Stellar stealth address', () => {
+    const composable = useStealthKeys('stellar');
+    const result = composable.generateAddress(new Uint8Array(32), new Uint8Array(32));
+    expect(result).toEqual(mockStellarAddress);
+    expect(composable.stealthAddress.value).toEqual(mockStellarAddress);
+  });
+
+  it('checks EVM stealth address', () => {
+    const composable = useStealthKeys('evm');
+    const result = composable.checkAddress(
+      '0x' + '03'.repeat(33),
+      '0x' + 'cd'.repeat(32),
+      '0x' + 'ef'.repeat(33),
+      42,
+    );
+    expect(result.isMatch).toBe(true);
+  });
+
+  it('checks Stellar stealth address', () => {
+    const composable = useStealthKeys('stellar');
+    const result = composable.checkAddress(
+      new Uint8Array(32),
+      new Uint8Array(32),
+      new Uint8Array(32),
+      42,
+    );
+    expect(result.isMatch).toBe(true);
+  });
+
+  it('derives EVM private key', () => {
+    const composable = useStealthKeys('evm');
+    const result = composable.derivePrivateKey(
+      '0x' + 'ab'.repeat(32),
+      '0x' + '03'.repeat(33),
+      '0x' + 'cd'.repeat(32),
+    );
+    expect(result).toBe('0x' + '04'.repeat(32));
+  });
+
+  it('derives Stellar private scalar', () => {
+    const composable = useStealthKeys('stellar');
+    const result = composable.derivePrivateKey(1n, new Uint8Array(32), new Uint8Array(32));
+    expect(result).toBe(3n);
+  });
+
+  it('setChain changes active chain', () => {
+    const composable = useStealthKeys('stellar');
+    expect(composable.chain.value).toBe('stellar');
+    composable.setChain('evm');
+    expect(composable.chain.value).toBe('evm');
+  });
+
+  it('manages loading state', () => {
+    const composable = useStealthKeys('stellar');
+    composable.deriveKeys(new Uint8Array(64));
+    expect(composable.loading.value).toBe(false);
+  });
+
+  it('error state is null initially', () => {
+    const composable = useStealthKeys('stellar');
+    expect(composable.error.value).toBeNull();
+  });
+
+  it('keys is null initially', () => {
+    const composable = useStealthKeys('stellar');
+    expect(composable.keys.value).toBeNull();
+  });
+
+  it('stealthAddress is null initially', () => {
+    const composable = useStealthKeys('stellar');
+    expect(composable.stealthAddress.value).toBeNull();
+  });
+});

--- a/packages/sdk-vue/test/useStellarStealthKeys.test.ts
+++ b/packages/sdk-vue/test/useStellarStealthKeys.test.ts
@@ -16,6 +16,15 @@ const mockAddress = vi.hoisted(() => ({
   viewTag: 42,
 }));
 
+const mockStreamFactory = vi.hoisted(() => {
+  return function createEmptyStream() {
+    async function* gen() {
+      yield* [];
+    }
+    return gen();
+  };
+});
+
 vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
   deriveStealthKeys: vi.fn().mockReturnValue(mockKeys),
   generateStealthAddress: vi.fn().mockReturnValue(mockAddress),
@@ -33,7 +42,7 @@ vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
     spendingPubKey: new Uint8Array(32),
     viewingPubKey: new Uint8Array(32),
   }),
-  fetchAnnouncements: vi.fn().mockResolvedValue([]),
+  fetchAnnouncementsStream: vi.fn().mockImplementation(() => mockStreamFactory()),
 }));
 
 describe('useStellarStealthKeys', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,31 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  examples/stellar-vue-receive:
+    dependencies:
+      '@wraith-protocol/sdk':
+        specifier: workspace:*
+        version: link:../..
+      '@wraith-protocol/sdk-vue':
+        specifier: workspace:*
+        version: link:../../packages/sdk-vue
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.39(typescript@5.9.3)
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: ^5.0.0
+        version: 5.2.4(vite@6.4.3(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vue@3.5.39(typescript@5.9.3))
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vue-tsc:
+        specifier: ^2.0.0
+        version: 2.2.12(typescript@5.9.3)
+
   examples/svelte-stellar-app:
     dependencies:
       '@wraith-protocol/sdk':
@@ -480,10 +505,6 @@ packages:
 
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -1830,7 +1851,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.18.31':
     resolution: {integrity: sha512-v9llw9fT3Uv+TCM6Xllo54t672CuYtinEQZ2LPJ2EJsCwuTc4Cd2gXQaouuIVD21VoeGQnr5JtJuWbF97sBKzQ==}
@@ -4926,11 +4947,6 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.15:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -6765,7 +6781,7 @@ snapshots:
 
   '@babel/code-frame@7.29.0':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -6918,8 +6934,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
-
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.29.7': {}
@@ -6939,7 +6953,7 @@ snapshots:
 
   '@babel/highlight@7.25.9':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       chalk: 2.4.2
       js-tokens: 4.0.0
       picocolors: 1.1.1
@@ -12197,8 +12211,6 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.15: {}
 
   nanoid@5.1.16: {}
@@ -12520,7 +12532,7 @@ snapshots:
 
   postcss@8.4.49:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -12532,7 +12544,7 @@ snapshots:
 
   postcss@8.5.9:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -13747,7 +13759,7 @@ snapshots:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.16
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:
@@ -13763,7 +13775,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.16
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Summary

Ports the missing hooks from **sdk-react** to **sdk-vue** using Vue Composition API, bringing `@wraith-protocol/sdk-vue` to parity with the React hook set.

## What's New

### Composables

| Composable | Purpose | Chains |
|---|---|---|
| `useStealthKeys(chain?)` | Key derivation & stealth address generation | EVM, Stellar, Solana |
| `useScanner(chain?)` | Announcement scanning with reactive state | EVM, Stellar, Solana |
| `useMetaAddress()` | Encode/decode stealth meta addresses (alias) | EVM, Stellar, Solana |
| `useActivity()` | Multi-chain activity event feed | EVM, Stellar, Solana |

Each composable accepts a `chain` parameter (`'evm'`, `'stellar'`, `'solana'`) and dispatches to the correct chain-specific SDK primitives internally.

### Bug Fix

Fixed `useStellarStealthKeys` — replaced stale `fetchAnnouncements` import (no longer exported) with `fetchAnnouncementsStream` (async generator API). A `collectAnnouncements` helper collects the generator into an array.

### Test Coverage

73 tests across 9 test files — all pass.

| Test file | Tests |
|---|---|
| `useStealthKeys.test.ts` | 16 |
| `useScanner.test.ts` | 13 |
| `useMetaAddress.test.ts` | 9 |
| `useActivity.test.ts` | 7 |
| (5 existing test files) | 28 |

### Example App

`examples/stellar-vue-receive/` — Vue 3 + Vite app demonstrating:
- Deriving stealth keys from a 64-byte hex secret key
- Generating a stealth meta-address
- Decoding the meta-address

Run with: `pnpm --filter @wraith-protocol/example-stellar-vue-receive dev`

## Files Changed

- `packages/sdk-vue/src/composables/useStealthKeys.ts` — new
- `packages/sdk-vue/src/composables/useScanner.ts` — new
- `packages/sdk-vue/src/composables/useMetaAddress.ts` — new
- `packages/sdk-vue/src/composables/useActivity.ts` — new
- `packages/sdk-vue/src/composables/useStellarStealthKeys.ts` — fixed `fetchAnnouncements` → `fetchAnnouncementsStream`
- `packages/sdk-vue/src/index.ts` — exports
- `packages/sdk-vue/test/` — 4 new test files
- `examples/stellar-vue-receive/` — new example app

## Verification

- ✅ `pnpm build` passes (ESM + CJS + DTS)
- ✅ `pnpm test` — 73 tests pass in sdk-vue
- ✅ `pnpm build` in example app passes

# Closes #128
