### PR TITLE
perf(stellar): pipeline streaming scan to overlap RPC fetch with decrypt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Wraith Protocol SDK will be documented in this file.
 
 ## Upcoming: 2.0.0
 
+### Performance
+
+- **Stellar Streaming Scan Pipelining** (issue #126): `scanAnnouncementsStream` now pulls its `source` through a bounded pipeline (`src/chains/stellar/scanner/pipeline.ts`) instead of prefetching a strict window before scanning it, so RPC fetches for later pages overlap with CPU work scanning earlier ones. Peak memory stays O(window). `fetchAnnouncementsStream` and `scanAnnouncementsStream`'s public shapes are unchanged; the old windowed algorithm is retained as `scanAnnouncementsStreamSequential` for benchmark comparisons. See [`docs/chains/stellar-streaming-scan-pipeline.md`](./docs/chains/stellar-streaming-scan-pipeline.md) — measured 36% wall-clock reduction on the 10k-announcement canned benchmark.
+
 ### Changed
 
 - **Stellar Chain Module Cryptographic Audit Fixes**: Applied all findings from independent cryptographic audit (issue #55). Breaking changes:

--- a/docs/chains/stellar-streaming-scan-pipeline.md
+++ b/docs/chains/stellar-streaming-scan-pipeline.md
@@ -1,0 +1,82 @@
+# Stellar streaming scan: overlapping RPC with CPU work
+
+## Problem
+
+`scanAnnouncementsStream` pulled announcements from its `source` in strict windows:
+await up to `window` items from the source, then scan all of them, then repeat. While a
+window was being scanned, the source (typically {@link fetchAnnouncementsStream} paging
+through Soroban RPC) sat idle — no fetch for the next page could start until the current
+window finished. On a cold scan, that serializes RPC latency and CPU decrypt cost that
+could otherwise overlap.
+
+## Chosen design
+
+`src/chains/stellar/scanner/pipeline.ts` adds a generic `pipeline(source, capacity)`
+helper: a bounded producer/consumer queue. A background pump keeps pulling from `source`
+up to `capacity` items ahead of what the consumer has read. Because starting the next pull
+from `source` kicks off its I/O immediately, that I/O runs concurrently with whatever
+synchronous work the consumer is doing on already-buffered items — Node's event loop keeps
+an in-flight `fetch()` progressing in the background while the main thread executes CPU
+work on the previous batch.
+
+`scanAnnouncementsStream` now wraps its `source` in `pipeline(source, window)` and scans
+each item as it's pulled from the pipeline, instead of prefetching a window strictly before
+scanning any of it:
+
+```ts
+const piped = pipeline(source, windowSize);
+for await (const ann of piped) {
+  // scan ann immediately; the pipeline is already fetching ahead in the background
+}
+```
+
+The pump pauses once `capacity` items are buffered, so an adversarially fast source paired
+with a slow scan still can't grow memory past O(window) — the same bound the old
+windowed implementation had.
+
+`fetchAnnouncementsStream`'s public shape is unchanged: it's still a plain async generator
+that yields one announcement at a time. `scanAnnouncementsStream`'s signature is also
+unchanged. The old windowed algorithm is kept as `scanAnnouncementsStreamSequential`,
+exported alongside `scanAnnouncementsStream` for benchmark comparisons, matching how
+`scanAnnouncementsLegacySharedSecretTag` is retained for the view-tag-batching benchmark.
+
+## Cancellation and errors
+
+Breaking out of the consumer's `for-await` loop calls `.return()` on the pipeline, which
+calls `.return()` on `source` in its `finally` block — the same cancellation contract the
+old implementation had, verified by the existing `scanAnnouncementsStream` cancellation
+test. Errors thrown by `source` propagate to the consumer once any already-buffered items
+are drained.
+
+## Benchmarks
+
+The benchmark harness lives at `test/chains/stellar/bench/scan.bench.ts`, in the "Stellar
+streaming scan pipelining" section. It mimics `fetchAnnouncementsStream`'s paging with a
+mock source that pays a fixed page latency (15ms) per 1,000-announcement page, then
+compares:
+
+1. `scanAnnouncementsStreamSequential` — window-then-scan, no overlap.
+2. `scanAnnouncementsStream` — pipelined fetch+scan.
+
+Run it with:
+
+```bash
+pnpm exec vitest bench test/chains/stellar/bench/scan.bench.ts --run
+```
+
+On this development container, the 10k-announcement canned dataset reported:
+
+| Dataset              | Before: sequential window | After: pipelined | Speedup |
+| -------------------- | ------------------------: | ---------------: | ------: |
+| 10,000 announcements |                 537.14 ms |        343.50 ms |   1.56x |
+
+That's a 36% reduction in wall-clock time, clearing the 30% target. The gain scales with
+how many pages a cold scan spans and how close `window` is to the source's page size —
+a `window` much smaller than the page size limits how far the pump can prefetch ahead of
+the scan.
+
+`test/chains/stellar/scanner/pipeline.test.ts` additionally asserts the underlying overlap
+mechanism directly (a mock producer/consumer pair with matched I/O and CPU delays), and
+asserts the bounded-queue backpressure property with a fast producer paired with an
+artificially slow consumer, so both acceptance criteria run under `pnpm test`, not just the
+excluded `bench/` folder.

--- a/src/chains/stellar/scan.ts
+++ b/src/chains/stellar/scan.ts
@@ -4,10 +4,12 @@ import { hashToScalar, deriveStealthPubKey, pubKeyToStellarAddress, L } from './
 import { SCHEME_ID, SCHEME_ID_V2 } from './constants';
 import type { Announcement, MatchedAnnouncement } from './types';
 import { hexToBytes } from './utils';
+import { pipeline } from './scanner/pipeline';
 
 /**
- * Streaming announcement scanner. Pulls announcements from `source` in windows of
- * `opts.window` (default 64), scans each window, and yields matches immediately.
+ * Streaming announcement scanner. Pipelines `source` through a bounded queue
+ * of size `opts.window` (default 64) so fetching stays ahead of decryption,
+ * and yields matches as soon as they're found.
  *
  * Uses the cheap public view-tag prefilter before the X25519 shared secret:
  *   1. Derive the viewing public key once from the viewing seed
@@ -16,13 +18,22 @@ import { hexToBytes } from './utils';
  *   4. Compute hash_scalar = SHA-256("wraith:scalar:" || S) mod L
  *   5. Expected stealth pubkey = K_spend + hash_scalar * G
  *   6. Compare with announced stealth address
- * Peak memory is O(window) — never accumulates the full announcement set.
+ *
+ * Unlike fetching all announcements up front and then scanning them, `source` is
+ * pulled continuously in the background (see {@link pipeline}) while each buffered
+ * announcement is scanned, so RPC round-trips for later pages overlap with the CPU
+ * cost of scanning earlier ones instead of running strictly one after the other.
+ * Peak memory is still O(window) — the queue never buffers more than `window`
+ * announcements ahead of the scan, so a fast source paired with a slow scan
+ * doesn't grow memory unbounded.
+ *
  * Cancellation is clean: breaking out of the `for-await` loop triggers the `finally`
- * block which calls `.return()` on the source iterator, stopping upstream I/O.
+ * block which stops the pipeline, which in turn calls `.return()` on the source
+ * iterator, stopping upstream I/O.
  *
  * @param source  Async iterable of announcements (e.g. from {@link fetchAnnouncementsStream}).
- * @param opts.window  Max announcements buffered at once. Smaller = less memory, larger = fewer
- *                     async round-trips to the source. Default: 64.
+ * @param opts.window  Max announcements buffered ahead of the scan. Smaller = less memory,
+ *                     larger = more overlap between fetching and scanning. Default: 64.
  */
 export async function* scanAnnouncementsStream(
   source: AsyncIterable<Announcement>,
@@ -32,11 +43,71 @@ export async function* scanAnnouncementsStream(
   opts: { window?: number } = {},
 ): AsyncGenerator<MatchedAnnouncement> {
   const windowSize = Math.max(1, opts.window ?? 64);
+  const viewingPubKey = ed25519.getPublicKey(viewingKey);
+  const piped = pipeline(source, windowSize);
+
+  try {
+    for await (const ann of piped) {
+      if (ann.schemeId !== SCHEME_ID && ann.schemeId !== SCHEME_ID_V2) continue;
+
+      const metadataBytes = hexToBytes(ann.metadata);
+      if (metadataBytes.length === 0) continue;
+      const viewTag = metadataBytes[0];
+
+      const ephPubKey = hexToBytes(ann.ephemeralPubKey);
+      if (ephPubKey.length !== 32) continue;
+
+      const result = checkStealthAddressWithViewingPubKey(
+        ephPubKey,
+        viewingKey,
+        viewingPubKey,
+        spendingPubKey,
+        viewTag,
+      );
+
+      if (
+        result.isMatch &&
+        result.stealthAddress === ann.stealthAddress &&
+        result.hashScalar !== null &&
+        result.stealthPubKeyBytes !== null
+      ) {
+        const stealthPrivateScalar = ((spendingScalar % L) + result.hashScalar) % L;
+        yield {
+          ...ann,
+          stealthPrivateScalar,
+          stealthPubKeyBytes: result.stealthPubKeyBytes,
+        };
+      }
+    }
+  } finally {
+    // Signal the pipeline (and transitively the source) to stop when consumer cancels early
+    await piped.return(undefined);
+  }
+}
+
+/**
+ * Pre-pipelining scanner retained for benchmarks.
+ *
+ * Matches the old streaming scan path: it prefetches up to `window` announcements
+ * strictly before scanning any of them, so no RPC fetch for the next window can
+ * start until the current window is fully scanned. {@link scanAnnouncementsStream}
+ * replaced this with a pipelined version that overlaps fetching with scanning.
+ *
+ * @see {@link scanAnnouncementsStream}
+ */
+export async function* scanAnnouncementsStreamSequential(
+  source: AsyncIterable<Announcement>,
+  viewingKey: Uint8Array,
+  spendingPubKey: Uint8Array,
+  spendingScalar: bigint,
+  opts: { window?: number } = {},
+): AsyncGenerator<MatchedAnnouncement> {
+  const windowSize = Math.max(1, opts.window ?? 64);
+  const viewingPubKey = ed25519.getPublicKey(viewingKey);
   const iter = source[Symbol.asyncIterator]();
 
   try {
     while (true) {
-      // Prefetch up to windowSize announcements — bounds peak memory to O(window)
       const batch: Announcement[] = [];
       for (let i = 0; i < windowSize; i++) {
         const next = await iter.next();
@@ -56,7 +127,13 @@ export async function* scanAnnouncementsStream(
         const ephPubKey = hexToBytes(ann.ephemeralPubKey);
         if (ephPubKey.length !== 32) continue;
 
-        const result = checkStealthAddress(ephPubKey, viewingKey, spendingPubKey, viewTag);
+        const result = checkStealthAddressWithViewingPubKey(
+          ephPubKey,
+          viewingKey,
+          viewingPubKey,
+          spendingPubKey,
+          viewTag,
+        );
 
         if (
           result.isMatch &&
@@ -76,7 +153,6 @@ export async function* scanAnnouncementsStream(
       if (batch.length < windowSize) break;
     }
   } finally {
-    // Signal upstream to stop I/O when consumer cancels early
     await iter.return?.();
   }
 }

--- a/src/chains/stellar/scanner/index.ts
+++ b/src/chains/stellar/scanner/index.ts
@@ -1,0 +1,1 @@
+export { pipeline } from './pipeline';

--- a/src/chains/stellar/scanner/pipeline.ts
+++ b/src/chains/stellar/scanner/pipeline.ts
@@ -1,0 +1,93 @@
+/** Resolvable/rejectable promise used to gate the producer and consumer loops. */
+class Deferred<T = void> {
+  readonly promise: Promise<T>;
+  resolve!: (value: T) => void;
+
+  constructor() {
+    this.promise = new Promise<T>((resolve) => {
+      this.resolve = resolve;
+    });
+  }
+}
+
+/**
+ * Pipelines an async iterable through a bounded in-memory queue so a slow
+ * consumer (e.g. CPU-bound decryption) overlaps with a producer that is
+ * mostly waiting on I/O (e.g. RPC pagination), instead of alternating
+ * "await a full page, then process it" in lockstep.
+ *
+ * A background pump continuously pulls from `source` and buffers up to
+ * `capacity` items ahead of what the consumer has read. Because pulling the
+ * next item from `source` starts its I/O immediately, that I/O runs
+ * concurrently with whatever synchronous work the consumer is doing on
+ * already-buffered items — Node's event loop keeps the in-flight network
+ * call progressing in the background while the main thread executes the
+ * consumer's CPU-bound step.
+ *
+ * The pump pauses once the queue is full, so an adversarially fast producer
+ * paired with a slow consumer cannot grow memory past O(capacity) items.
+ *
+ * Breaking out of the consumer's `for-await` loop (or calling `.return()`)
+ * propagates to `source` via its `.return()`, matching plain async-generator
+ * cancellation semantics.
+ *
+ * @param source Async iterable to pull from (e.g. {@link fetchAnnouncementsStream}).
+ * @param capacity Max items buffered ahead of the consumer. Must be >= 1.
+ */
+export async function* pipeline<T>(source: AsyncIterable<T>, capacity: number): AsyncGenerator<T> {
+  const cap = Math.max(1, capacity);
+  const buffer: T[] = [];
+  let producerDone = false;
+  let producerErrored = false;
+  let producerError: unknown;
+
+  let itemAvailable = new Deferred();
+  let spaceAvailable = new Deferred();
+  spaceAvailable.resolve();
+
+  const iter = source[Symbol.asyncIterator]();
+
+  const pump = (async () => {
+    try {
+      while (true) {
+        if (buffer.length >= cap) {
+          await spaceAvailable.promise;
+          spaceAvailable = new Deferred();
+        }
+
+        const next = await iter.next();
+        if (next.done) break;
+
+        buffer.push(next.value);
+        itemAvailable.resolve();
+      }
+    } catch (err) {
+      producerErrored = true;
+      producerError = err;
+    } finally {
+      producerDone = true;
+      itemAvailable.resolve();
+    }
+  })();
+
+  try {
+    while (true) {
+      if (buffer.length === 0) {
+        if (producerDone) {
+          if (producerErrored) throw producerError;
+          break;
+        }
+        await itemAvailable.promise;
+        itemAvailable = new Deferred();
+        continue;
+      }
+
+      const value = buffer.shift() as T;
+      spaceAvailable.resolve();
+      yield value;
+    }
+  } finally {
+    await iter.return?.();
+    await pump.catch(() => {});
+  }
+}

--- a/test/chains/stellar/bench/scan.bench.ts
+++ b/test/chains/stellar/bench/scan.bench.ts
@@ -8,6 +8,8 @@ import {
 } from '../../../../src/chains/stellar/stealth';
 import {
   scanAnnouncements,
+  scanAnnouncementsStream,
+  scanAnnouncementsStreamSequential,
   scanAnnouncementsLegacySharedSecretTag,
 } from '../../../../src/chains/stellar/scan';
 import { SCHEME_ID } from '../../../../src/chains/stellar/constants';
@@ -43,12 +45,6 @@ function makeAnnouncementFor(
   tagScheme: 'legacy-shared-secret' | 'public-announcement',
 ): Announcement {
   const stealth = generateStealthAddress(
-async function makeAnnouncementFor(
-  recipient: StealthKeys,
-  ephemeralSeed: Uint8Array,
-  tagScheme: 'legacy-shared-secret' | 'public-announcement',
-): Promise<Announcement> {
-  const stealth = await generateStealthAddress(
     recipient.spendingPubKey,
     recipient.viewingPubKey,
     ephemeralSeed,
@@ -85,32 +81,6 @@ const matchingAnnouncements = {
 function makeDataset(size: number, tagScheme: 'legacy' | 'optimized') {
   const foreignPool = pools[tagScheme];
   const matchingAnnouncement = matchingAnnouncements[tagScheme];
-let pools: { legacy: Announcement[]; optimized: Announcement[] } | undefined;
-let matchingAnnouncements: { legacy: Announcement; optimized: Announcement } | undefined;
-
-async function initFixtures() {
-  if (pools && matchingAnnouncements) return;
-  pools = {
-    legacy: await Promise.all(
-      Array.from({ length: POOL_SIZE }, (_, i) =>
-        makeAnnouncementFor(foreignKeys, seedFor(i), 'legacy-shared-secret'),
-      ),
-    ),
-    optimized: await Promise.all(
-      Array.from({ length: POOL_SIZE }, (_, i) =>
-        makeAnnouncementFor(foreignKeys, seedFor(i), 'public-announcement'),
-      ),
-    ),
-  };
-  matchingAnnouncements = {
-    legacy: await makeAnnouncementFor(keys, seedFor(POOL_SIZE + 1), 'legacy-shared-secret'),
-    optimized: await makeAnnouncementFor(keys, seedFor(POOL_SIZE + 1), 'public-announcement'),
-  };
-}
-
-function makeDataset(size: number, tagScheme: 'legacy' | 'optimized') {
-  const foreignPool = pools![tagScheme];
-  const matchingAnnouncement = matchingAnnouncements![tagScheme];
 
   return Array.from({ length: size }, (_, i) =>
     i === MATCH_INDEX ? matchingAnnouncement : foreignPool[i % foreignPool.length],
@@ -133,28 +103,6 @@ describe('Stellar scan benchmark fixtures', () => {
     expect(dataset).toBeDefined();
 
     const matched = scanAnnouncements(
-async function getDatasets(): Promise<
-  Map<number, { legacy: Announcement[]; optimized: Announcement[] }>
-> {
-  await initFixtures();
-  return new Map(
-    DATASET_SIZES.map((size) => [
-      size,
-      {
-        legacy: makeDataset(size, 'legacy'),
-        optimized: makeDataset(size, 'optimized'),
-      },
-    ]),
-  );
-}
-
-describe('Stellar scan benchmark fixtures', () => {
-  test('optimized scanner preserves correctness on the 10k synthetic dataset', async () => {
-    const datasets = await getDatasets();
-    const dataset = datasets.get(10_000)?.optimized;
-    expect(dataset).toBeDefined();
-
-    const matched = await scanAnnouncements(
       dataset!,
       keys.viewingKey,
       keys.spendingPubKey,
@@ -163,7 +111,6 @@ describe('Stellar scan benchmark fixtures', () => {
 
     expect(matched).toHaveLength(1);
     expect(matched[0].stealthAddress).toBe(matchingAnnouncements.optimized.stealthAddress);
-    expect(matched[0].stealthAddress).toBe(matchingAnnouncements!.optimized.stealthAddress);
   });
 });
 
@@ -175,12 +122,6 @@ describe('Stellar scan announcement view-tag batching', () => {
       `before: shared-secret view tag (${size.toLocaleString()} announcements)`,
       () => {
         scanAnnouncementsLegacySharedSecretTag(
-    bench(
-      `before: shared-secret view tag (${size.toLocaleString()} announcements)`,
-      async () => {
-        const datasets = await getDatasets();
-        const dataset = datasets.get(size)!;
-        await scanAnnouncementsLegacySharedSecretTag(
           dataset.legacy,
           keys.viewingKey,
           keys.spendingPubKey,
@@ -194,14 +135,98 @@ describe('Stellar scan announcement view-tag batching', () => {
       `after: public view-tag prefilter (${size.toLocaleString()} announcements)`,
       () => {
         scanAnnouncements(
-      async () => {
-        const datasets = await getDatasets();
-        const dataset = datasets.get(size)!;
-        await scanAnnouncements(
           dataset.optimized,
           keys.viewingKey,
           keys.spendingPubKey,
           keys.spendingScalar,
+        );
+      },
+      BENCH_OPTIONS,
+    );
+  }
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Mimics fetchAnnouncementsStream's paging: one simulated RPC round trip per
+ * `pageSize` announcements, each paying `pageLatencyMs` before its events are
+ * available to the scanner.
+ */
+function paginatedMockSource(
+  items: Announcement[],
+  pageSize: number,
+  pageLatencyMs: number,
+): AsyncGenerator<Announcement> {
+  return (async function* () {
+    for (let offset = 0; offset < items.length; offset += pageSize) {
+      await sleep(pageLatencyMs);
+      const page = items.slice(offset, offset + pageSize);
+      for (const item of page) yield item;
+    }
+  })();
+}
+
+async function drain<T>(source: AsyncIterable<T>): Promise<T[]> {
+  const results: T[] = [];
+  for await (const value of source) results.push(value);
+  return results;
+}
+
+const PAGE_SIZE = 1_000;
+const PAGE_LATENCY_MS = 15;
+
+describe('Stellar streaming scan pipelining', () => {
+  test('pipelined scan finds the same match as the sequential scan', async () => {
+    const dataset = datasets.get(10_000)?.optimized;
+    expect(dataset).toBeDefined();
+
+    const matched = await drain(
+      scanAnnouncementsStream(
+        paginatedMockSource(dataset!, PAGE_SIZE, PAGE_LATENCY_MS),
+        keys.viewingKey,
+        keys.spendingPubKey,
+        keys.spendingScalar,
+        { window: PAGE_SIZE },
+      ),
+    );
+
+    expect(matched).toHaveLength(1);
+    expect(matched[0].stealthAddress).toBe(matchingAnnouncements.optimized.stealthAddress);
+  });
+
+  for (const size of DATASET_SIZES) {
+    const dataset = datasets.get(size)!.optimized;
+
+    bench(
+      `before: sequential window fetch-then-scan (${size.toLocaleString()} announcements)`,
+      async () => {
+        await drain(
+          scanAnnouncementsStreamSequential(
+            paginatedMockSource(dataset, PAGE_SIZE, PAGE_LATENCY_MS),
+            keys.viewingKey,
+            keys.spendingPubKey,
+            keys.spendingScalar,
+            { window: PAGE_SIZE },
+          ),
+        );
+      },
+      BENCH_OPTIONS,
+    );
+
+    bench(
+      `after: pipelined fetch+scan (${size.toLocaleString()} announcements)`,
+      async () => {
+        await drain(
+          scanAnnouncementsStream(
+            paginatedMockSource(dataset, PAGE_SIZE, PAGE_LATENCY_MS),
+            keys.viewingKey,
+            keys.spendingPubKey,
+            keys.spendingScalar,
+            { window: PAGE_SIZE },
+          ),
         );
       },
       BENCH_OPTIONS,

--- a/test/chains/stellar/scanner/pipeline.test.ts
+++ b/test/chains/stellar/scanner/pipeline.test.ts
@@ -1,0 +1,121 @@
+import { describe, test, expect } from 'vitest';
+import { pipeline } from '../../../../src/chains/stellar/scanner/pipeline';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('pipeline', () => {
+  test('yields every item from the source in order', async () => {
+    async function* source(): AsyncGenerator<number> {
+      for (let i = 0; i < 100; i++) yield i;
+    }
+
+    const results: number[] = [];
+    for await (const value of pipeline(source(), 8)) {
+      results.push(value);
+    }
+
+    expect(results).toEqual(Array.from({ length: 100 }, (_, i) => i));
+  });
+
+  test('overlaps producer I/O with consumer CPU work', async () => {
+    const count = 15;
+    const ioDelayMs = 20;
+    const cpuDelayMs = 20;
+
+    function makeMockRpc(): AsyncGenerator<number> {
+      return (async function* () {
+        for (let i = 0; i < count; i++) {
+          await sleep(ioDelayMs);
+          yield i;
+        }
+      })();
+    }
+
+    // Measure an actual sequential "fetch item, then process it" baseline on this
+    // machine/OS instead of computing one from nominal delays, since timer
+    // granularity varies enough (especially on Windows) to make a theoretical
+    // estimate an unreliable comparison point.
+    const sequentialStart = Date.now();
+    for await (const _value of makeMockRpc()) {
+      await sleep(cpuDelayMs);
+    }
+    const sequentialElapsed = Date.now() - sequentialStart;
+
+    const pipelinedStart = Date.now();
+    // Capacity covers the whole source so the producer can run as far ahead
+    // as it wants, giving the best case for overlap and the least timer jitter.
+    for await (const _value of pipeline(makeMockRpc(), count)) {
+      await sleep(cpuDelayMs);
+    }
+    const pipelinedElapsed = Date.now() - pipelinedStart;
+
+    // Assert at least a 25% improvement over the measured sequential baseline,
+    // leaving margin for scheduler jitter beyond the theoretical ~50% ideal.
+    expect(pipelinedElapsed).toBeLessThan(sequentialElapsed * 0.75);
+  });
+
+  test('backpressure bounds how far the producer can run ahead of a slow consumer', async () => {
+    const capacity = 4;
+    let produced = 0;
+
+    async function* fastSource(): AsyncGenerator<number> {
+      for (let i = 0; i < 50; i++) {
+        produced++;
+        yield i;
+      }
+    }
+
+    let consumed = 0;
+    let maxLead = 0;
+    for await (const _value of pipeline(fastSource(), capacity)) {
+      await sleep(2);
+      consumed++;
+      maxLead = Math.max(maxLead, produced - consumed);
+    }
+
+    expect(consumed).toBe(50);
+    // Small slack above `capacity` for the one item already in flight when the
+    // queue is measured, not unbounded growth from the fast producer.
+    expect(maxLead).toBeLessThanOrEqual(capacity + 2);
+  });
+
+  test('propagates cancellation to the source generator', async () => {
+    let sourceReturned = false;
+
+    async function* infinite(): AsyncGenerator<number> {
+      try {
+        let i = 0;
+        while (true) yield i++;
+      } finally {
+        sourceReturned = true;
+      }
+    }
+
+    const results: number[] = [];
+    for await (const value of pipeline(infinite(), 4)) {
+      results.push(value);
+      if (results.length === 3) break;
+    }
+
+    expect(results).toEqual([0, 1, 2]);
+    expect(sourceReturned).toBe(true);
+  });
+
+  test('propagates source errors to the consumer', async () => {
+    async function* failing(): AsyncGenerator<number> {
+      yield 1;
+      throw new Error('boom');
+    }
+
+    const results: number[] = [];
+    await expect(async () => {
+      for await (const value of pipeline(failing(), 4)) {
+        results.push(value);
+      }
+    }).rejects.toThrow('boom');
+
+    expect(results).toEqual([1]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add a generic bounded-queue `pipeline(source, capacity)` helper in `src/chains/stellar/scanner/pipeline.ts`. A background pump keeps pulling from `source` up to `capacity` items ahead of the consumer, so the next RPC fetch's I/O is already in flight while the consumer does CPU-bound work on already-buffered items, instead of alternating "await a full window, then process it."
- `scanAnnouncementsStream` now wraps its `source` in `pipeline(source, window)` instead of prefetching a strict window before scanning any of it. Peak memory stays O(window); cancellation and error propagation are unchanged.
- The old windowed algorithm is kept as `scanAnnouncementsStreamSequential` for benchmark comparisons, matching how `scanAnnouncementsLegacySharedSecretTag` is retained for the view-tag-batching benchmark.
- Fixed `test/chains/stellar/bench/scan.bench.ts`, which had corrupted/duplicated content on `develop` (left over from an earlier merge) making it fail to even parse — unrelated to this change but blocking it since I needed to extend that file.
- Docs in `docs/chains/stellar-streaming-scan-pipeline.md`, changelog entry under the upcoming release.

Closes #126.

## Semver

Additive-only: new internal module (`src/chains/stellar/scanner/`, not part of the public package exports) plus a new benchmark-only export `scanAnnouncementsStreamSequential`. `fetchAnnouncementsStream` and `scanAnnouncementsStream`'s public signatures and behavior are unchanged.

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` — full suite passes (793 passed in the Stellar module, no regressions)
- [x] New `test/chains/stellar/scanner/pipeline.test.ts` (runs under `pnpm test`, not excluded like `bench/`): order preservation, overlap timing (pipelined run is reliably ≥25% faster than a measured sequential baseline with matched I/O/CPU delays), backpressure bound with a fast producer + slow consumer, cancellation propagation, error propagation
- [x] `test/chains/stellar/bench/scan.bench.ts` — new "Stellar streaming scan pipelining" section: correctness test plus `before`/`after` benchmarks against a mock paginated RPC source; measured **36% wall-clock reduction** on the 10k-announcement canned dataset (537ms → 343ms), clearing the 30% target
- [x] Existing `scanAnnouncementsStream` tests (window sizing, cancellation, memory-bounded) pass unmodified
- [x] `pnpm format:check`