### PR TITLE
feat(agent): add Claude-compatible Stellar agent tools wrapper

### DIFF
--- a/src/agent/tools.ts
+++ b/src/agent/tools.ts
@@ -1,0 +1,149 @@
+import { deriveStealthKeys } from '../chains/stellar/keys';
+import { decodeStealthMetaAddress, encodeStealthMetaAddress } from '../chains/stellar/meta-address';
+import { generateStealthAddress } from '../chains/stellar/stealth';
+import { scanAnnouncements } from '../chains/stellar/scan';
+import { hexToBytes, bytesToHex } from '../chains/stellar/utils';
+import type { Announcement } from '../chains/stellar/types';
+
+export interface ClaudeAgentToolContext {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
+export interface SendToMetaAddressInput {
+  metaAddress: string;
+  amount: string;
+  asset?: string;
+  memo?: string;
+  destination?: string;
+}
+
+export interface ScanInput {
+  announcements: Announcement[];
+  viewingKeyHex: string;
+  spendingPubKeyHex: string;
+  spendingScalarHex: string;
+}
+
+export interface WithdrawInput {
+  stealthAddress: string;
+  amount: string;
+  asset?: string;
+  destination?: string;
+  memo?: string;
+}
+
+export interface ResolveNameInput {
+  name: string;
+  chain?: string;
+}
+
+export interface ToolResult {
+  kind: 'send' | 'scan' | 'withdraw' | 'resolve-name';
+  signingRequired: boolean;
+  tx?: Record<string, unknown>;
+  metaAddress?: string;
+  matches?: Array<Record<string, unknown>>;
+  count?: number;
+  name?: string;
+  chain?: string;
+  note?: string;
+}
+
+export interface ClaudeAgentTools {
+  sendToMetaAddress(input: SendToMetaAddressInput): Promise<ToolResult>;
+  scan(input: ScanInput): Promise<ToolResult>;
+  withdraw(input: WithdrawInput): Promise<ToolResult>;
+  resolveName(input: ResolveNameInput): Promise<ToolResult>;
+}
+
+function parseHexBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  return hexToBytes(clean);
+}
+
+function parseBigInt(value: string | undefined): bigint {
+  if (!value) return 0n;
+  const clean = value.startsWith('0x') || value.startsWith('0X') ? value : value;
+  if (/^0x/i.test(clean)) return BigInt(clean);
+  if (/^[0-9]+$/u.test(clean)) return BigInt(clean);
+  return BigInt(`0x${clean}`);
+}
+
+export function createClaudeAgentTools(_context: ClaudeAgentToolContext = {}): ClaudeAgentTools {
+  return {
+    async sendToMetaAddress(input) {
+      const { spendingPubKey, viewingPubKey } = decodeStealthMetaAddress(input.metaAddress);
+      const stealthResult = generateStealthAddress(spendingPubKey, viewingPubKey);
+      return {
+        kind: 'send',
+        signingRequired: true,
+        metaAddress: input.metaAddress,
+        tx: {
+          intent: 'send-to-meta-address',
+          asset: input.asset ?? 'XLM',
+          amount: input.amount,
+          memo: input.memo ?? '',
+          stealthAddress: stealthResult.stealthAddress,
+          ephemeralPubKey: bytesToHex(stealthResult.ephemeralPubKey),
+          metadata: stealthResult.viewTag.toString(16).padStart(2, '0'),
+          destination: input.destination ?? stealthResult.stealthAddress,
+        },
+        note: 'The agent prepares a stealth send plan. The sender must sign the transaction locally with their wallet.',
+      };
+    },
+
+    async scan(input) {
+      const viewingKey = parseHexBytes(input.viewingKeyHex);
+      const spendingPubKey = parseHexBytes(input.spendingPubKeyHex);
+      const spendingScalar = parseBigInt(input.spendingScalarHex);
+      const matches = scanAnnouncements(
+        input.announcements,
+        viewingKey,
+        spendingPubKey,
+        spendingScalar,
+      );
+      return {
+        kind: 'scan',
+        signingRequired: false,
+        matches: matches.map((item) => ({
+          stealthAddress: item.stealthAddress,
+          ephemeralPubKey: item.ephemeralPubKey,
+          metadata: item.metadata,
+          stealthPrivateScalar: item.stealthPrivateScalar.toString(),
+        })),
+        count: matches.length,
+      };
+    },
+
+    async withdraw(input) {
+      return {
+        kind: 'withdraw',
+        signingRequired: true,
+        tx: {
+          intent: 'withdraw',
+          stealthAddress: input.stealthAddress,
+          asset: input.asset ?? 'XLM',
+          amount: input.amount,
+          destination: input.destination ?? input.stealthAddress,
+          memo: input.memo ?? '',
+        },
+        note: 'The agent prepares a withdrawal plan. The stealth account owner must sign the transaction with their local wallet or key manager.',
+      };
+    },
+
+    async resolveName(input) {
+      return {
+        kind: 'resolve-name',
+        signingRequired: false,
+        name: input.name,
+        chain: input.chain ?? 'stellar',
+        tx: {
+          intent: 'resolve-name',
+          name: input.name,
+          chain: input.chain ?? 'stellar',
+        },
+      };
+    },
+  };
+}

--- a/test/agent/tools.test.ts
+++ b/test/agent/tools.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import { createClaudeAgentTools } from '../../src/agent/tools';
+import { deriveStealthKeys } from '../../src/chains/stellar/keys';
+import { encodeStealthMetaAddress } from '../../src/chains/stellar/meta-address';
+
+describe('Claude agent tools', () => {
+  test('send-to-meta-address builds a signing plan without signing', async () => {
+    const tools = createClaudeAgentTools();
+    const keys = deriveStealthKeys(new Uint8Array(64).fill(0xaa));
+    const metaAddress = encodeStealthMetaAddress(keys.spendingPubKey, keys.viewingPubKey);
+
+    const result = await tools.sendToMetaAddress({
+      metaAddress,
+      amount: '12.5',
+      asset: 'XLM',
+      memo: 'agent demo',
+    });
+
+    expect(result.kind).toBe('send');
+    expect(result.metaAddress).toBe(metaAddress);
+    expect(result.signingRequired).toBe(true);
+    expect(result.tx).toBeDefined();
+  });
+
+  test('scan tool returns matches for a synthetic announcement batch', async () => {
+    const tools = createClaudeAgentTools();
+    const keys = deriveStealthKeys(new Uint8Array(64).fill(0xaa));
+    const stealth = {
+      stealthAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      ephemeralPubKey: new Uint8Array(32).fill(0x11),
+      viewTag: 7,
+    };
+
+    const result = await tools.scan({
+      announcements: [
+        {
+          schemeId: 1,
+          stealthAddress: stealth.stealthAddress,
+          caller: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+          ephemeralPubKey: '1111111111111111111111111111111111111111111111111111111111111111',
+          metadata: '07',
+        },
+      ],
+      viewingKeyHex: Buffer.from(keys.viewingKey).toString('hex'),
+      spendingPubKeyHex: Buffer.from(keys.spendingPubKey).toString('hex'),
+      spendingScalarHex: keys.spendingScalar.toString(16),
+    });
+
+    expect(result.matches).toEqual([]);
+    expect(result.count).toBe(0);
+  });
+
+  test('withdraw tool builds a withdrawal plan', async () => {
+    const tools = createClaudeAgentTools();
+    const result = await tools.withdraw({
+      stealthAddress: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      amount: '3',
+      asset: 'XLM',
+      destination: 'GA1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890',
+    });
+
+    expect(result.kind).toBe('withdraw');
+    expect(result.signingRequired).toBe(true);
+    expect(result.tx).toBeDefined();
+  });
+
+  test('resolve-name tool returns a structured resolution payload', async () => {
+    const tools = createClaudeAgentTools();
+    const result = await tools.resolveName({ name: 'alice', chain: 'stellar' });
+
+    expect(result.kind).toBe('resolve-name');
+    expect(result.name).toBe('alice');
+    expect(result.chain).toBe('stellar');
+  });
+});


### PR DESCRIPTION
Added a Claude-compatible Stellar agent tools wrapper in [tools.ts](https://laughing-space-dollop-4q74v9774979cj599.github.dev/).
Included tool methods for [sendToMetaAddress](https://laughing-space-dollop-4q74v9774979cj599.github.dev/), [scan](https://laughing-space-dollop-4q74v9774979cj599.github.dev/), [withdraw](https://laughing-space-dollop-4q74v9774979cj599.github.dev/), and [resolveName](https://laughing-space-dollop-4q74v9774979cj599.github.dev/).
Added tests in [tools.test.ts](https://laughing-space-dollop-4q74v9774979cj599.github.dev/).
No public API changes to existing SDK exports.
closes #133 