### PR TITLE
feat(stellar): add batch transaction builder

### DIFF
--- a/src/chains/stellar/index.ts
+++ b/src/chains/stellar/index.ts
@@ -67,6 +67,13 @@ export type { SorobanEventFilter, SorobanTopicMatcher } from './event-filters';
 export { DEPLOYMENTS, getDeployment } from './deployments';
 export { StellarBatchBuilder, encodeAnnouncementData, decodeAnnouncementData } from './batch';
 export type { StealthPaymentConfig, BatchConfig, BuildResult } from './batch';
+export {
+  buildBatchSendTx,
+  buildAnnouncementData,
+  STELLAR_MAX_OPERATIONS,
+  DEFAULT_BASE_FEE,
+  DEFAULT_BATCH_SENDER_THRESHOLD,
+} from './tx-builder';
 export type { StellarChainDeployment } from './deployments';
 export type {
   HexString,
@@ -76,6 +83,9 @@ export type {
   GeneratedStealthAddress,
   Announcement,
   MatchedAnnouncement,
+  StealthPayment,
+  BuildBatchSendTxParams,
+  BuildBatchSendTxResult,
 } from './types';
 
 export { buildStellarSwapAndStealth } from './swap';

--- a/src/chains/stellar/tx-builder.ts
+++ b/src/chains/stellar/tx-builder.ts
@@ -1,0 +1,158 @@
+import { decodeStealthMetaAddress } from './meta-address';
+import { generateStealthAddress } from './stealth';
+import { bytesToHex } from './utils';
+import { SCHEME_ID } from './constants';
+import type {
+  GeneratedStealthAddress,
+  StealthPayment,
+  BuildBatchSendTxParams,
+  BuildBatchSendTxResult,
+} from './types';
+
+/**
+ * Stellar operation count limit.
+ * The Stellar protocol limits transactions to 100 operations.
+ */
+export const STELLAR_MAX_OPERATIONS = 100;
+
+/**
+ * Default base fee per operation in stroops.
+ */
+export const DEFAULT_BASE_FEE = 100;
+
+/**
+ * Default threshold for using stealth-batch-sender contract.
+ */
+export const DEFAULT_BATCH_SENDER_THRESHOLD = 10;
+
+/**
+ * Builds a Stellar transaction that sends XLM to multiple stealth addresses.
+ *
+ * This function:
+ * - Generates stealth addresses for each recipient
+ * - Builds a transaction with payment operations
+ * - Scales fees based on operation count
+ * - Validates against operation count limits
+ * - Optionally uses stealth-batch-sender contract for large batches
+ *
+ * @param params Batch send transaction parameters
+ * @returns Built transaction ready for signing
+ * @throws Error if payment count exceeds max operations
+ */
+export function buildBatchSendTx(params: BuildBatchSendTxParams): BuildBatchSendTxResult {
+  const {
+    payments,
+    sourceAccount,
+    memo,
+    networkPassphrase,
+    baseFee = DEFAULT_BASE_FEE,
+    maxOperations = STELLAR_MAX_OPERATIONS,
+    batchSenderThreshold = DEFAULT_BATCH_SENDER_THRESHOLD,
+    batchSenderContract,
+  } = params;
+
+  // Validate payment count
+  if (payments.length === 0) {
+    throw new Error('Payments array cannot be empty');
+  }
+
+  if (payments.length > maxOperations) {
+    throw new Error(
+      `Payment count (${payments.length}) exceeds maximum operations per transaction (${maxOperations})`
+    );
+  }
+
+  // Generate stealth addresses for all payments
+  const stealthAddresses: GeneratedStealthAddress[] = payments.map((payment) => {
+    const { spendingPubKey, viewingPubKey } = decodeStealthMetaAddress(payment.metaAddress);
+    return generateStealthAddress(spendingPubKey, viewingPubKey);
+  });
+
+  // Determine if we should use stealth-batch-sender contract
+  const useBatchSender =
+    batchSenderContract !== undefined && payments.length >= batchSenderThreshold;
+
+  // Load Stellar SDK dynamically (peer dependency)
+  const { TransactionBuilder, Operation, Memo, Asset } = require('@stellar/stellar-sdk');
+
+  // Calculate total fee with scaling
+  // Fee scales with operation count to ensure timely inclusion
+  const operationCount = useBatchSender ? 1 : payments.length;
+  const totalFee = operationCount * baseFee;
+
+  // Start building the transaction
+  let builder = new TransactionBuilder(sourceAccount, {
+    fee: totalFee.toString(),
+    networkPassphrase,
+  });
+
+  // Add memo if provided
+  if (memo) {
+    if (memo.length <= 28) {
+      builder = builder.addMemo(Memo.text(memo));
+    } else if (memo.length <= 64) {
+      builder = builder.addMemo(Memo.hash(memo));
+    } else {
+      throw new Error('Memo too long: max 28 characters for text, 64 for hash');
+    }
+  }
+
+  if (useBatchSender && batchSenderContract) {
+    // Use stealth-batch-sender contract for large batches
+    // This would call a Soroban contract that handles the batch efficiently
+    // For now, this is a placeholder - the actual contract implementation
+    // would be added when the contract is deployed
+    throw new Error(
+      'stealth-batch-sender contract integration not yet implemented. ' +
+        'Please provide batchSenderContract only when the contract is deployed.'
+    );
+  } else {
+    // Build individual payment operations
+    for (let i = 0; i < payments.length; i++) {
+      const payment = payments[i];
+      const stealth = stealthAddresses[i];
+
+      builder = builder.addOperation(
+        Operation.payment({
+          destination: stealth.stealthAddress,
+          asset: Asset.native(),
+          amount: payment.amount,
+        })
+      );
+    }
+  }
+
+  // Set timeout (30 seconds default)
+  builder = builder.setTimeout(30);
+
+  // Build the transaction
+  const transaction = builder.build();
+
+  return {
+    transaction,
+    stealthAddresses,
+    totalFee,
+    usedBatchSender: useBatchSender,
+  };
+}
+
+/**
+ * Builds announcement data for stealth payments.
+ * This can be used to publish announcements after sending payments.
+ *
+ * @param stealthAddresses Generated stealth addresses
+ * @param caller Sender's Stellar public key
+ * @returns Array of announcement objects ready for the announcer contract
+ */
+export function buildAnnouncementData(
+  stealthAddresses: GeneratedStealthAddress[],
+  caller: string,
+): Array<{ schemeId: number; stealthAddress: string; caller: string; ephemeralPubKey: string; metadata: string }> {
+  return stealthAddresses.map((stealth) => ({
+    schemeId: SCHEME_ID,
+    stealthAddress: stealth.stealthAddress,
+    caller,
+    ephemeralPubKey: bytesToHex(stealth.ephemeralPubKey),
+    metadata: stealth.viewTag.toString(16).padStart(2, '0'),
+  }));
+}

--- a/src/chains/stellar/tx-builder.ts
+++ b/src/chains/stellar/tx-builder.ts
@@ -58,7 +58,7 @@ export function buildBatchSendTx(params: BuildBatchSendTxParams): BuildBatchSend
 
   if (payments.length > maxOperations) {
     throw new Error(
-      `Payment count (${payments.length}) exceeds maximum operations per transaction (${maxOperations})`
+      `Payment count (${payments.length}) exceeds maximum operations per transaction (${maxOperations})`,
     );
   }
 
@@ -104,7 +104,7 @@ export function buildBatchSendTx(params: BuildBatchSendTxParams): BuildBatchSend
     // would be added when the contract is deployed
     throw new Error(
       'stealth-batch-sender contract integration not yet implemented. ' +
-        'Please provide batchSenderContract only when the contract is deployed.'
+        'Please provide batchSenderContract only when the contract is deployed.',
     );
   } else {
     // Build individual payment operations
@@ -117,7 +117,7 @@ export function buildBatchSendTx(params: BuildBatchSendTxParams): BuildBatchSend
           destination: stealth.stealthAddress,
           asset: Asset.native(),
           amount: payment.amount,
-        })
+        }),
       );
     }
   }
@@ -147,7 +147,13 @@ export function buildBatchSendTx(params: BuildBatchSendTxParams): BuildBatchSend
 export function buildAnnouncementData(
   stealthAddresses: GeneratedStealthAddress[],
   caller: string,
-): Array<{ schemeId: number; stealthAddress: string; caller: string; ephemeralPubKey: string; metadata: string }> {
+): Array<{
+  schemeId: number;
+  stealthAddress: string;
+  caller: string;
+  ephemeralPubKey: string;
+  metadata: string;
+}> {
   return stealthAddresses.map((stealth) => ({
     schemeId: SCHEME_ID,
     stealthAddress: stealth.stealthAddress,

--- a/src/chains/stellar/types.ts
+++ b/src/chains/stellar/types.ts
@@ -248,16 +248,62 @@ export interface ExtractContractSpecOptions {
 export interface ExtractedContractSpec {
   /** Contract identifier used for extraction. */
   contractId: string;
+
   /** Stellar network used to resolve the RPC URL. */
   network: Network;
+
   /** Effective Soroban RPC URL used for extraction. */
   rpcUrl: string;
+
   /** Current deployed Wasm hash for cache versioning. */
   wasmHash: HexString;
+
   /** Normalized function signatures. */
   functions: ContractFunctionSpec[];
+
   /** Normalized user-defined types. */
   types: ContractUserTypeSpec[];
+
   /** Generated TypeScript declarations when requested. */
   typescript?: string;
+}
+
+/** Payment details for a single stealth payment recipient. */
+export interface StealthPayment {
+  /** Recipient's stealth meta-address (st:xlm:...) */
+  metaAddress: string;
+  /** Amount in XLM (string to preserve precision) */
+  amount: string;
+}
+
+/** Parameters for building a batch send transaction. */
+export interface BuildBatchSendTxParams {
+  /** Array of stealth payments to include in the batch */
+  payments: StealthPayment[];
+  /** Stellar source account object with sequence number */
+  sourceAccount: any;
+  /** Optional memo for the transaction */
+  memo?: string;
+  /** Network passphrase (e.g., 'Test SDF Network ; September 2015') */
+  networkPassphrase: string;
+  /** Base fee per operation in stroops (default: 100) */
+  baseFee?: number;
+  /** Maximum operations allowed per transaction (default: 100) */
+  maxOperations?: number;
+  /** Threshold for using stealth-batch-sender contract (default: 10) */
+  batchSenderThreshold?: number;
+  /** Optional stealth-batch-sender contract address */
+  batchSenderContract?: string;
+}
+
+/** Result of building a batch send transaction. */
+export interface BuildBatchSendTxResult {
+  /** The built Stellar transaction (TransactionBuilder output) */
+  transaction: any;
+  /** Generated stealth addresses for each payment */
+  stealthAddresses: GeneratedStealthAddress[];
+  /** Total fee in stroops */
+  totalFee: number;
+  /** Whether stealth-batch-sender contract was used */
+  usedBatchSender: boolean;
 }

--- a/test/chains/stellar/tx-builder.test.ts
+++ b/test/chains/stellar/tx-builder.test.ts
@@ -17,7 +17,7 @@ const networkPassphrase = 'Test SDF Network ; September 2015';
 const { Account } = require('@stellar/stellar-sdk');
 const sourceAccount = new Account(
   'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-  '123456789'
+  '123456789',
 );
 
 describe('tx-builder: buildBatchSendTx', () => {
@@ -97,7 +97,7 @@ describe('tx-builder: buildBatchSendTx', () => {
         payments: [],
         sourceAccount,
         networkPassphrase,
-      })
+      }),
     ).toThrow('Payments array cannot be empty');
   });
 
@@ -112,11 +112,11 @@ describe('tx-builder: buildBatchSendTx', () => {
         payments,
         sourceAccount,
         networkPassphrase,
-      })
+      }),
     ).toThrow(
       new RegExp(
-        `Payment count \\(${STELLAR_MAX_OPERATIONS + 1}\\) exceeds maximum operations per transaction \\(${STELLAR_MAX_OPERATIONS}\\)`
-      )
+        `Payment count \\(${STELLAR_MAX_OPERATIONS + 1}\\) exceeds maximum operations per transaction \\(${STELLAR_MAX_OPERATIONS}\\)`,
+      ),
     );
   });
 
@@ -133,9 +133,11 @@ describe('tx-builder: buildBatchSendTx', () => {
         sourceAccount,
         networkPassphrase,
         maxOperations: customMax,
-      })
+      }),
     ).toThrow(
-      new RegExp(`Payment count \\(11\\) exceeds maximum operations per transaction \\(${customMax}\\)`)
+      new RegExp(
+        `Payment count \\(11\\) exceeds maximum operations per transaction \\(${customMax}\\)`,
+      ),
     );
   });
 
@@ -228,15 +230,18 @@ describe('tx-builder: buildBatchSendTx', () => {
         sourceAccount,
         networkPassphrase,
         memo: longMemo,
-      })
+      }),
     ).toThrow('Memo too long');
   });
 
   test('throws error when batchSenderContract is provided but not implemented', () => {
-    const payments: StealthPayment[] = Array.from({ length: DEFAULT_BATCH_SENDER_THRESHOLD }, () => ({
-      metaAddress,
-      amount: '1',
-    }));
+    const payments: StealthPayment[] = Array.from(
+      { length: DEFAULT_BATCH_SENDER_THRESHOLD },
+      () => ({
+        metaAddress,
+        amount: '1',
+      }),
+    );
 
     expect(() =>
       buildBatchSendTx({
@@ -244,15 +249,18 @@ describe('tx-builder: buildBatchSendTx', () => {
         sourceAccount,
         networkPassphrase,
         batchSenderContract: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-      })
+      }),
     ).toThrow('stealth-batch-sender contract integration not yet implemented');
   });
 
   test('does not use batch sender below threshold', () => {
-    const payments: StealthPayment[] = Array.from({ length: DEFAULT_BATCH_SENDER_THRESHOLD - 1 }, () => ({
-      metaAddress,
-      amount: '1',
-    }));
+    const payments: StealthPayment[] = Array.from(
+      { length: DEFAULT_BATCH_SENDER_THRESHOLD - 1 },
+      () => ({
+        metaAddress,
+        amount: '1',
+      }),
+    );
 
     const result = buildBatchSendTx({
       payments,

--- a/test/chains/stellar/tx-builder.test.ts
+++ b/test/chains/stellar/tx-builder.test.ts
@@ -1,0 +1,341 @@
+import { describe, test, expect } from 'vitest';
+import { deriveStealthKeys } from '../../../src/chains/stellar/keys';
+import { encodeStealthMetaAddress } from '../../../src/chains/stellar/meta-address';
+import {
+  buildBatchSendTx,
+  buildAnnouncementData,
+  STELLAR_MAX_OPERATIONS,
+  DEFAULT_BASE_FEE,
+  DEFAULT_BATCH_SENDER_THRESHOLD,
+} from '../../../src/chains/stellar/tx-builder';
+import type { StealthPayment } from '../../../src/chains/stellar/types';
+
+const testSig = new Uint8Array(64).fill(0xaa);
+const networkPassphrase = 'Test SDF Network ; September 2015';
+
+// Create a mock Stellar Account object
+const { Account } = require('@stellar/stellar-sdk');
+const sourceAccount = new Account(
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+  '123456789'
+);
+
+describe('tx-builder: buildBatchSendTx', () => {
+  const keys = deriveStealthKeys(testSig);
+  const metaAddress = encodeStealthMetaAddress(keys.spendingPubKey, keys.viewingPubKey);
+
+  test('builds transaction with 1 destination', () => {
+    const payments: StealthPayment[] = [
+      {
+        metaAddress,
+        amount: '10',
+      },
+    ];
+
+    const result = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+    });
+
+    expect(result.transaction).toBeDefined();
+    expect(result.stealthAddresses).toHaveLength(1);
+    expect(result.totalFee).toBe(DEFAULT_BASE_FEE);
+    expect(result.usedBatchSender).toBe(false);
+    expect(result.stealthAddresses[0].stealthAddress).toMatch(/^G[A-Z2-7]{55}$/);
+  });
+
+  test('builds transaction with 5 destinations', () => {
+    const payments: StealthPayment[] = Array.from({ length: 5 }, () => ({
+      metaAddress,
+      amount: '5',
+    }));
+
+    const result = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+    });
+
+    expect(result.transaction).toBeDefined();
+    expect(result.stealthAddresses).toHaveLength(5);
+    expect(result.totalFee).toBe(5 * DEFAULT_BASE_FEE);
+    expect(result.usedBatchSender).toBe(false);
+
+    // Verify all stealth addresses are unique (different ephemeral keys)
+    const addresses = result.stealthAddresses.map((s) => s.stealthAddress);
+    const uniqueAddresses = new Set(addresses);
+    expect(uniqueAddresses.size).toBe(5);
+  });
+
+  test('builds transaction with 20 destinations', () => {
+    const payments: StealthPayment[] = Array.from({ length: 20 }, () => ({
+      metaAddress,
+      amount: '1',
+    }));
+
+    const result = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+    });
+
+    expect(result.transaction).toBeDefined();
+    expect(result.stealthAddresses).toHaveLength(20);
+    expect(result.totalFee).toBe(20 * DEFAULT_BASE_FEE);
+    expect(result.usedBatchSender).toBe(false);
+
+    // Verify all stealth addresses are unique
+    const addresses = result.stealthAddresses.map((s) => s.stealthAddress);
+    const uniqueAddresses = new Set(addresses);
+    expect(uniqueAddresses.size).toBe(20);
+  });
+
+  test('rejects empty payments array', () => {
+    expect(() =>
+      buildBatchSendTx({
+        payments: [],
+        sourceAccount,
+        networkPassphrase,
+      })
+    ).toThrow('Payments array cannot be empty');
+  });
+
+  test('rejects batches over operation count cap', () => {
+    const payments: StealthPayment[] = Array.from({ length: STELLAR_MAX_OPERATIONS + 1 }, () => ({
+      metaAddress,
+      amount: '1',
+    }));
+
+    expect(() =>
+      buildBatchSendTx({
+        payments,
+        sourceAccount,
+        networkPassphrase,
+      })
+    ).toThrow(
+      new RegExp(
+        `Payment count \\(${STELLAR_MAX_OPERATIONS + 1}\\) exceeds maximum operations per transaction \\(${STELLAR_MAX_OPERATIONS}\\)`
+      )
+    );
+  });
+
+  test('rejects batches over custom max operations', () => {
+    const customMax = 10;
+    const payments: StealthPayment[] = Array.from({ length: 11 }, () => ({
+      metaAddress,
+      amount: '1',
+    }));
+
+    expect(() =>
+      buildBatchSendTx({
+        payments,
+        sourceAccount,
+        networkPassphrase,
+        maxOperations: customMax,
+      })
+    ).toThrow(
+      new RegExp(`Payment count \\(11\\) exceeds maximum operations per transaction \\(${customMax}\\)`)
+    );
+  });
+
+  test('accepts batch exactly at operation count cap', () => {
+    const payments: StealthPayment[] = Array.from({ length: STELLAR_MAX_OPERATIONS }, () => ({
+      metaAddress,
+      amount: '1',
+    }));
+
+    const result = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+    });
+
+    expect(result.transaction).toBeDefined();
+    expect(result.stealthAddresses).toHaveLength(STELLAR_MAX_OPERATIONS);
+    expect(result.totalFee).toBe(STELLAR_MAX_OPERATIONS * DEFAULT_BASE_FEE);
+  });
+
+  test('applies custom base fee', () => {
+    const customFee = 200;
+    const payments: StealthPayment[] = [
+      {
+        metaAddress,
+        amount: '10',
+      },
+    ];
+
+    const result = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+      baseFee: customFee,
+    });
+
+    expect(result.totalFee).toBe(customFee);
+  });
+
+  test('scales fee with operation count', () => {
+    const customFee = 150;
+    const payments: StealthPayment[] = Array.from({ length: 5 }, () => ({
+      metaAddress,
+      amount: '1',
+    }));
+
+    const result = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+      baseFee: customFee,
+    });
+
+    expect(result.totalFee).toBe(5 * customFee);
+  });
+
+  test('adds text memo when provided', () => {
+    const memo = 'Payroll Q1';
+    const payments: StealthPayment[] = [
+      {
+        metaAddress,
+        amount: '10',
+      },
+    ];
+
+    const result = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+      memo,
+    });
+
+    expect(result.transaction).toBeDefined();
+    const txMemo = result.transaction.memo;
+    expect(txMemo).toBeDefined();
+  });
+
+  test('rejects memo that is too long', () => {
+    const longMemo = 'a'.repeat(65);
+    const payments: StealthPayment[] = [
+      {
+        metaAddress,
+        amount: '10',
+      },
+    ];
+
+    expect(() =>
+      buildBatchSendTx({
+        payments,
+        sourceAccount,
+        networkPassphrase,
+        memo: longMemo,
+      })
+    ).toThrow('Memo too long');
+  });
+
+  test('throws error when batchSenderContract is provided but not implemented', () => {
+    const payments: StealthPayment[] = Array.from({ length: DEFAULT_BATCH_SENDER_THRESHOLD }, () => ({
+      metaAddress,
+      amount: '1',
+    }));
+
+    expect(() =>
+      buildBatchSendTx({
+        payments,
+        sourceAccount,
+        networkPassphrase,
+        batchSenderContract: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      })
+    ).toThrow('stealth-batch-sender contract integration not yet implemented');
+  });
+
+  test('does not use batch sender below threshold', () => {
+    const payments: StealthPayment[] = Array.from({ length: DEFAULT_BATCH_SENDER_THRESHOLD - 1 }, () => ({
+      metaAddress,
+      amount: '1',
+    }));
+
+    const result = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+      batchSenderContract: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    });
+
+    expect(result.usedBatchSender).toBe(false);
+  });
+});
+
+describe('tx-builder: buildAnnouncementData', () => {
+  const keys = deriveStealthKeys(testSig);
+  const metaAddress = encodeStealthMetaAddress(keys.spendingPubKey, keys.viewingPubKey);
+  const caller = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+  test('builds announcement data for single stealth address', () => {
+    const payments: StealthPayment[] = [
+      {
+        metaAddress,
+        amount: '10',
+      },
+    ];
+
+    const txResult = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+    });
+
+    const announcementData = buildAnnouncementData(txResult.stealthAddresses, caller);
+
+    expect(announcementData).toHaveLength(1);
+    expect(announcementData[0].schemeId).toBe(1);
+    expect(announcementData[0].stealthAddress).toBe(txResult.stealthAddresses[0].stealthAddress);
+    expect(announcementData[0].caller).toBe(caller);
+    expect(announcementData[0].ephemeralPubKey).toMatch(/^[0-9a-f]{64}$/);
+    expect(announcementData[0].metadata).toMatch(/^[0-9a-f]{2}$/);
+  });
+
+  test('builds announcement data for multiple stealth addresses', () => {
+    const payments: StealthPayment[] = Array.from({ length: 5 }, () => ({
+      metaAddress,
+      amount: '1',
+    }));
+
+    const txResult = buildBatchSendTx({
+      payments,
+      sourceAccount,
+      networkPassphrase,
+    });
+
+    const announcementData = buildAnnouncementData(txResult.stealthAddresses, caller);
+
+    expect(announcementData).toHaveLength(5);
+
+    // Verify each announcement has correct structure
+    announcementData.forEach((ann, i) => {
+      expect(ann.schemeId).toBe(1);
+      expect(ann.stealthAddress).toBe(txResult.stealthAddresses[i].stealthAddress);
+      expect(ann.caller).toBe(caller);
+      expect(ann.ephemeralPubKey).toMatch(/^[0-9a-f]{64}$/);
+      expect(ann.metadata).toMatch(/^[0-9a-f]{2}$/);
+    });
+
+    // Verify ephemeral keys are unique
+    const ephKeys = announcementData.map((a) => a.ephemeralPubKey);
+    const uniqueKeys = new Set(ephKeys);
+    expect(uniqueKeys.size).toBe(5);
+  });
+});
+
+describe('tx-builder: constants', () => {
+  test('exports correct max operations constant', () => {
+    expect(STELLAR_MAX_OPERATIONS).toBe(100);
+  });
+
+  test('exports correct default base fee constant', () => {
+    expect(DEFAULT_BASE_FEE).toBe(100);
+  });
+
+  test('exports correct default batch sender threshold', () => {
+    expect(DEFAULT_BATCH_SENDER_THRESHOLD).toBe(10);
+  });
+});


### PR DESCRIPTION
Closes #139

---

**## Summary**

Implements a Stellar batch transaction builder for stealth payments.

### Changes

* Added `buildBatchSendTx()` for constructing multi-recipient Stellar transactions.
* Added fee scaling based on operation count.
* Added configurable operation-count limit with descriptive validation errors.
* Added threshold logic for future `stealth-batch-sender` contract integration.
* Returns transactions ready for external signature collection.
* Added test coverage for:

  * Single recipient
  * 5 recipients
  * 20 recipients
  * Operation limit validation
  * Threshold crossover behavior

### Notes

* The `stealth-batch-sender` integration is intentionally stubbed until the contract is available.
* The threshold selection logic is implemented and covered by tests.