### PR TITLE
feat(sdk-svelte): match React Stellar hooks

### DIFF
--- a/examples/stellar-svelte-receive/README.md
+++ b/examples/stellar-svelte-receive/README.md
@@ -1,0 +1,12 @@
+# Stellar Svelte receive
+
+A minimal Svelte 5 app that uses `@wraith-protocol/sdk-svelte` to derive a Stellar
+stealth meta-address and scan recent on-chain announcements.
+
+```bash
+pnpm --filter @wraith-protocol/sdk-svelte build
+pnpm --filter @wraith-protocol/example-stellar-svelte-receive dev
+```
+
+Set `VITE_STELLAR_SECRET_KEY` to prefill the 64-byte hexadecimal secret, or paste
+one in the app. Scanning uses the Stellar deployment configured by the core SDK.

--- a/examples/stellar-svelte-receive/index.html
+++ b/examples/stellar-svelte-receive/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Receive and scan Stellar stealth payments with Wraith." />
+    <title>Wraith Stellar Receive</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/examples/stellar-svelte-receive/package.json
+++ b/examples/stellar-svelte-receive/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@wraith-protocol/example-stellar-svelte-receive",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@stellar/stellar-sdk": "^13.1.0",
+    "@wraith-protocol/sdk-svelte": "workspace:*",
+    "svelte": "^5.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "typescript": "^5.7.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/examples/stellar-svelte-receive/src/App.svelte
+++ b/examples/stellar-svelte-receive/src/App.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+  import {
+    useStellarAnnouncementScan,
+    useStellarStealthKeys,
+  } from '@wraith-protocol/sdk-svelte';
+
+  const {
+    keys,
+    metaAddress,
+    error: keyError,
+    generate,
+    encodeMetaAddress,
+  } = useStellarStealthKeys();
+  const { announcements, scanning, error: scanError, scan } = useStellarAnnouncementScan();
+
+  let secret = $state(import.meta.env.VITE_STELLAR_SECRET_KEY ?? '');
+  let validationError = $state<string | null>(null);
+
+  function parseSecret(value: string): Uint8Array | null {
+    const hex = value.trim().replace(/^0x/i, '');
+    if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length % 2 !== 0) return null;
+    return new Uint8Array(hex.match(/.{2}/g)!.map((byte) => Number.parseInt(byte, 16)));
+  }
+
+  function derive() {
+    validationError = null;
+    const signature = parseSecret(secret);
+    if (!signature) {
+      validationError = 'Enter an even-length hexadecimal secret.';
+      return;
+    }
+    if (signature.length !== 64) {
+      validationError = `Expected 64 bytes, received ${signature.length}.`;
+      return;
+    }
+
+    const derived = generate(signature);
+    encodeMetaAddress(derived.spendingPubKey, derived.viewingPubKey);
+  }
+
+  async function scanPayments() {
+    try {
+      await scan({});
+    } catch {
+      // The error store renders the actionable network or RPC message.
+    }
+  }
+
+  function hex(bytes: Uint8Array): string {
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+</script>
+
+<svelte:head>
+  <title>Wraith Stellar Receive</title>
+</svelte:head>
+
+<main>
+  <p class="eyebrow">Wraith Protocol · Svelte</p>
+  <h1>Receive Stellar stealth payments</h1>
+  <p class="intro">
+    Derive a shareable stealth meta-address, then scan Stellar for payments announced to it.
+  </p>
+
+  <section>
+    <h2>1. Derive your receive address</h2>
+    <label for="secret">64-byte secret (hex)</label>
+    <textarea
+      id="secret"
+      bind:value={secret}
+      rows="4"
+      spellcheck="false"
+      placeholder="128 hexadecimal characters"
+    ></textarea>
+    <button type="button" onclick={derive}>Derive stealth keys</button>
+
+    {#if validationError || $keyError}
+      <p class="error" role="alert">{validationError ?? $keyError}</p>
+    {/if}
+
+    {#if $keys && $metaAddress}
+      <div class="result">
+        <span>Stealth meta-address</span>
+        <code>{$metaAddress}</code>
+        <details>
+          <summary>View public keys</summary>
+          <dl>
+            <dt>Spending</dt>
+            <dd>{hex($keys.spendingPubKey)}</dd>
+            <dt>Viewing</dt>
+            <dd>{hex($keys.viewingPubKey)}</dd>
+          </dl>
+        </details>
+      </div>
+    {/if}
+  </section>
+
+  <section>
+    <div class="section-heading">
+      <div>
+        <h2>2. Scan announcements</h2>
+        <p>Read recent announcements from the configured Stellar deployment.</p>
+      </div>
+      <button type="button" onclick={scanPayments} disabled={$scanning}>
+        {$scanning ? 'Scanning…' : 'Scan now'}
+      </button>
+    </div>
+
+    {#if $scanError}
+      <p class="error" role="alert">{$scanError.message}</p>
+    {:else if $announcements.length}
+      <ul>
+        {#each $announcements as announcement}
+          <li>
+            <code>{announcement.stealthAddress}</code>
+            <span>scheme {announcement.schemeId} · ledger {announcement.ledger ?? 'pending'}</span>
+          </li>
+        {/each}
+      </ul>
+    {:else}
+      <p class="empty">No announcements loaded yet.</p>
+    {/if}
+  </section>
+</main>
+
+<style>
+  :global(*) {
+    box-sizing: border-box;
+  }
+  :global(body) {
+    margin: 0;
+    min-width: 320px;
+    min-height: 100vh;
+    color: #e8ecf3;
+    background:
+      radial-gradient(circle at 15% 10%, rgba(84, 95, 255, 0.2), transparent 28rem),
+      #090b11;
+    font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  }
+  main {
+    width: min(760px, calc(100% - 32px));
+    margin: 0 auto;
+    padding: 72px 0;
+  }
+  .eyebrow {
+    margin: 0 0 12px;
+    color: #9ba7ff;
+    font-size: 0.78rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+  }
+  h1 {
+    max-width: 650px;
+    margin: 0;
+    font-size: clamp(2.4rem, 7vw, 4.8rem);
+    line-height: 0.98;
+    letter-spacing: -0.055em;
+  }
+  .intro {
+    max-width: 590px;
+    margin: 24px 0 42px;
+    color: #aeb6c7;
+    font-size: 1.08rem;
+    line-height: 1.65;
+  }
+  section {
+    margin-top: 18px;
+    padding: 26px;
+    border: 1px solid #242a39;
+    border-radius: 18px;
+    background: rgba(17, 20, 29, 0.88);
+  }
+  h2 {
+    margin: 0 0 18px;
+    font-size: 1.15rem;
+  }
+  label,
+  .result span {
+    display: block;
+    margin-bottom: 8px;
+    color: #aeb6c7;
+    font-size: 0.82rem;
+    font-weight: 650;
+  }
+  textarea {
+    width: 100%;
+    resize: vertical;
+    padding: 14px;
+    border: 1px solid #30384b;
+    border-radius: 10px;
+    outline: none;
+    color: #eff2fa;
+    background: #0c0f16;
+    font: 0.85rem/1.5 ui-monospace, SFMono-Regular, Consolas, monospace;
+  }
+  textarea:focus {
+    border-color: #737fff;
+    box-shadow: 0 0 0 3px rgba(115, 127, 255, 0.12);
+  }
+  button {
+    margin-top: 14px;
+    padding: 10px 16px;
+    border: 0;
+    border-radius: 9px;
+    color: white;
+    background: #5966e9;
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+  }
+  button:disabled {
+    cursor: wait;
+    opacity: 0.65;
+  }
+  .result {
+    margin-top: 22px;
+    padding: 16px;
+    border-radius: 12px;
+    background: #0c0f16;
+  }
+  code,
+  dd {
+    overflow-wrap: anywhere;
+    color: #bec5ff;
+    font-family: ui-monospace, SFMono-Regular, Consolas, monospace;
+  }
+  details {
+    margin-top: 16px;
+    color: #aeb6c7;
+  }
+  dl {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 8px 14px;
+    font-size: 0.78rem;
+  }
+  dd {
+    margin: 0;
+  }
+  .section-heading {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 24px;
+  }
+  .section-heading h2 {
+    margin-bottom: 5px;
+  }
+  .section-heading p,
+  .empty {
+    margin: 0;
+    color: #858fa3;
+  }
+  .section-heading button {
+    flex: 0 0 auto;
+    margin-top: 0;
+  }
+  .error {
+    color: #ff9b9b;
+  }
+  ul {
+    display: grid;
+    gap: 8px;
+    padding: 0;
+    list-style: none;
+  }
+  li {
+    display: flex;
+    justify-content: space-between;
+    gap: 14px;
+    padding: 12px;
+    border-radius: 9px;
+    background: #0c0f16;
+  }
+  li span {
+    flex: 0 0 auto;
+    color: #858fa3;
+    font-size: 0.8rem;
+  }
+  @media (max-width: 560px) {
+    main {
+      padding: 42px 0;
+    }
+    section {
+      padding: 20px;
+    }
+    .section-heading,
+    li {
+      flex-direction: column;
+    }
+  }
+</style>

--- a/examples/stellar-svelte-receive/src/main.ts
+++ b/examples/stellar-svelte-receive/src/main.ts
@@ -1,0 +1,6 @@
+import { mount } from 'svelte';
+import App from './App.svelte';
+
+mount(App, {
+  target: document.getElementById('app')!,
+});

--- a/examples/stellar-svelte-receive/src/vite-env.d.ts
+++ b/examples/stellar-svelte-receive/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/stellar-svelte-receive/svelte.config.js
+++ b/examples/stellar-svelte-receive/svelte.config.js
@@ -1,0 +1,5 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+export default {
+  preprocess: vitePreprocess(),
+};

--- a/examples/stellar-svelte-receive/tsconfig.json
+++ b/examples/stellar-svelte-receive/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.svelte"]
+}

--- a/examples/stellar-svelte-receive/vite.config.ts
+++ b/examples/stellar-svelte-receive/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+
+export default defineConfig({
+  plugins: [svelte()],
+});

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "vitest run --exclude 'test/chains/stellar/properties.test.ts' --exclude 'test/leaks/scan-leak.test.ts'",
+    "test": "vitest run --exclude 'test/chains/stellar/properties.test.ts' --exclude 'test/leaks/scan-leak.test.ts' && pnpm --filter @wraith-protocol/sdk-svelte test",
     "docs": "typedoc",
     "test:watch": "vitest",
     "bench": "vitest bench --run",

--- a/packages/sdk-svelte/package.json
+++ b/packages/sdk-svelte/package.json
@@ -25,10 +25,14 @@
     "@wraith-protocol/sdk": "workspace:*"
   },
   "peerDependencies": {
+    "@stellar/stellar-sdk": "^13.1.0",
     "@wraith-protocol/sdk": "workspace:*",
     "svelte": "^5.0.0"
   },
   "devDependencies": {
+    "@stellar/stellar-sdk": "^13.1.0",
+    "@testing-library/svelte": "^5.2.0",
+    "jsdom": "^25.0.0",
     "svelte": "^5.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.7.0",

--- a/packages/sdk-svelte/src/index.ts
+++ b/packages/sdk-svelte/src/index.ts
@@ -1,5 +1,9 @@
 export { useWraith } from './primitives/useWraith.js';
 export { useStellarStealthKeys } from './primitives/useStellarStealthKeys.js';
+export { useStellarAnnouncementScan } from './primitives/useStellarAnnouncementScan.js';
+export { useStellarSendStealthPayment } from './primitives/useStellarSendStealthPayment.js';
+export { useStellarBalance } from './primitives/useStellarBalance.js';
+export { useStellarName } from './primitives/useStellarName.js';
 export { useEvmStealthKeys } from './primitives/useEvmStealthKeys.js';
 export { useSolanaStealthKeys } from './primitives/useSolanaStealthKeys.js';
 export { useStealthMetaAddress } from './primitives/useStealthMetaAddress.js';

--- a/packages/sdk-svelte/src/primitives/useStellarAnnouncementScan.ts
+++ b/packages/sdk-svelte/src/primitives/useStellarAnnouncementScan.ts
@@ -1,0 +1,40 @@
+import { readonly, writable } from 'svelte/store';
+import {
+  fetchAnnouncementsStream,
+  type Announcement,
+  type FetchAnnouncementsOptions,
+} from '@wraith-protocol/sdk/chains/stellar';
+
+/** Store primitive for scanning Stellar stealth announcements. */
+export function useStellarAnnouncementScan() {
+  const _announcements = writable<Announcement[]>([]);
+  const _scanning = writable(false);
+  const _error = writable<Error | null>(null);
+
+  async function scan(options: FetchAnnouncementsOptions): Promise<Announcement[]> {
+    _scanning.set(true);
+    _error.set(null);
+
+    try {
+      const announcements: Announcement[] = [];
+      for await (const announcement of fetchAnnouncementsStream('stellar', options)) {
+        announcements.push(announcement);
+      }
+      _announcements.set(announcements);
+      return announcements;
+    } catch (cause) {
+      const error = cause instanceof Error ? cause : new Error(String(cause));
+      _error.set(error);
+      throw cause;
+    } finally {
+      _scanning.set(false);
+    }
+  }
+
+  return {
+    announcements: readonly(_announcements),
+    scanning: readonly(_scanning),
+    error: readonly(_error),
+    scan,
+  };
+}

--- a/packages/sdk-svelte/src/primitives/useStellarBalance.ts
+++ b/packages/sdk-svelte/src/primitives/useStellarBalance.ts
@@ -1,0 +1,30 @@
+import { Horizon } from '@stellar/stellar-sdk';
+import { readonly, writable } from 'svelte/store';
+
+/** Store primitive for loading an account's native Stellar balance. */
+export function useStellarBalance(publicKey: string, rpcUrl = 'https://horizon.stellar.org') {
+  const _balance = writable<string | null>(null);
+  const _loading = writable(false);
+
+  async function load() {
+    if (!publicKey) return;
+
+    _loading.set(true);
+    try {
+      const account = await new Horizon.Server(rpcUrl).loadAccount(publicKey);
+      const nativeBalance = account.balances.find((entry) => entry.asset_type === 'native');
+      _balance.set(nativeBalance ? nativeBalance.balance : '0');
+    } catch {
+      _balance.set('0');
+    } finally {
+      _loading.set(false);
+    }
+  }
+
+  void load();
+
+  return {
+    balance: readonly(_balance),
+    loading: readonly(_loading),
+  };
+}

--- a/packages/sdk-svelte/src/primitives/useStellarName.ts
+++ b/packages/sdk-svelte/src/primitives/useStellarName.ts
@@ -1,0 +1,34 @@
+import { getDeployment } from '@wraith-protocol/sdk/chains/stellar';
+import { readonly, writable } from 'svelte/store';
+
+/** Store primitive for resolving a Wraith name on Stellar. */
+export function useStellarName(name: string | undefined, chain = 'testnet') {
+  const _address = writable<string | null>(null);
+  const _loading = writable(false);
+  const _error = writable<Error | null>(null);
+
+  async function resolve() {
+    if (!name) return;
+
+    _loading.set(true);
+    _error.set(null);
+    try {
+      getDeployment(chain);
+      // Name resolution remains a placeholder until the core SDK exposes it.
+      await new Promise((resolveDelay) => setTimeout(resolveDelay, 500));
+      _address.set(null);
+    } catch (cause) {
+      _error.set(cause instanceof Error ? cause : new Error(String(cause)));
+    } finally {
+      _loading.set(false);
+    }
+  }
+
+  void resolve();
+
+  return {
+    address: readonly(_address),
+    loading: readonly(_loading),
+    error: readonly(_error),
+  };
+}

--- a/packages/sdk-svelte/src/primitives/useStellarSendStealthPayment.ts
+++ b/packages/sdk-svelte/src/primitives/useStellarSendStealthPayment.ts
@@ -1,0 +1,32 @@
+import { readonly, writable } from 'svelte/store';
+import {
+  buildStealthPayment,
+  type BuildStealthPaymentOptions,
+} from '@wraith-protocol/sdk/chains/stellar';
+
+/** Store primitive for building Stellar stealth payment transactions. */
+export function useStellarSendStealthPayment() {
+  const _building = writable(false);
+  const _error = writable<Error | null>(null);
+
+  async function build(options: BuildStealthPaymentOptions) {
+    _building.set(true);
+    _error.set(null);
+
+    try {
+      return await buildStealthPayment(options);
+    } catch (cause) {
+      const error = cause instanceof Error ? cause : new Error(String(cause));
+      _error.set(error);
+      throw cause;
+    } finally {
+      _building.set(false);
+    }
+  }
+
+  return {
+    building: readonly(_building),
+    error: readonly(_error),
+    build,
+  };
+}

--- a/packages/sdk-svelte/src/primitives/useStellarStealthKeys.ts
+++ b/packages/sdk-svelte/src/primitives/useStellarStealthKeys.ts
@@ -7,7 +7,7 @@ import {
   deriveStealthPrivateScalar,
   encodeStealthMetaAddress,
   decodeStealthMetaAddress,
-  fetchAnnouncements,
+  fetchAnnouncementsStream,
 } from '@wraith-protocol/sdk/chains/stellar';
 import type {
   StealthKeys,
@@ -40,6 +40,9 @@ export function useStellarStealthKeys() {
       _loading.set(false);
     }
   }
+
+  // React parity: `useStellarStealthKeys` exposes this operation as `generate`.
+  const generate = deriveKeys;
 
   function generateAddress(
     spendingPubKey: Uint8Array,
@@ -126,7 +129,13 @@ export function useStellarStealthKeys() {
     _loading.set(true);
     _error.set(null);
     try {
-      const list = await fetchAnnouncements(chain, sorobanUrl);
+      const list: Announcement[] = [];
+      for await (const announcement of fetchAnnouncementsStream(
+        chain ?? 'stellar',
+        sorobanUrl,
+      )) {
+        list.push(announcement);
+      }
       _announcements.set(list);
       return list;
     } catch (e) {
@@ -165,6 +174,7 @@ export function useStellarStealthKeys() {
     metaAddress: readonly(_metaAddress),
     loading: readonly(_loading),
     error: readonly(_error),
+    generate,
     deriveKeys,
     generateAddress,
     checkAddress,

--- a/packages/sdk-svelte/src/primitives/useStellarStealthKeys.ts
+++ b/packages/sdk-svelte/src/primitives/useStellarStealthKeys.ts
@@ -130,10 +130,7 @@ export function useStellarStealthKeys() {
     _error.set(null);
     try {
       const list: Announcement[] = [];
-      for await (const announcement of fetchAnnouncementsStream(
-        chain ?? 'stellar',
-        sorobanUrl,
-      )) {
+      for await (const announcement of fetchAnnouncementsStream(chain ?? 'stellar', sorobanUrl)) {
         list.push(announcement);
       }
       _announcements.set(list);

--- a/packages/sdk-svelte/test/StoreHarness.svelte
+++ b/packages/sdk-svelte/test/StoreHarness.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import type { Readable } from 'svelte/store';
+
+  let {
+    value,
+    run,
+  }: {
+    value: Readable<unknown>;
+    run?: () => unknown | Promise<unknown>;
+  } = $props();
+
+  function serialize(current: unknown): string {
+    return JSON.stringify(current, (_, item) => (typeof item === 'bigint' ? item.toString() : item));
+  }
+</script>
+
+{#if run}
+  <button type="button" onclick={() => void run()}>Run</button>
+{/if}
+<output data-testid="value">{serialize($value)}</output>

--- a/packages/sdk-svelte/test/stellarParity.test.ts
+++ b/packages/sdk-svelte/test/stellarParity.test.ts
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import StoreHarness from './StoreHarness.svelte';
+import {
+  useStellarAnnouncementScan,
+  useStellarBalance,
+  useStellarName,
+  useStellarSendStealthPayment,
+  useStellarStealthKeys,
+} from '../src/index.js';
+import { buildStealthPayment, fetchAnnouncementsStream } from '@wraith-protocol/sdk/chains/stellar';
+
+vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
+  META_ADDRESS_PREFIX: 'st:xlm:',
+  deriveStealthKeys: vi.fn(() => ({ marker: 'generated' })),
+  generateStealthAddress: vi.fn(),
+  checkStealthAddress: vi.fn(),
+  scanAnnouncements: vi.fn(),
+  deriveStealthPrivateScalar: vi.fn(),
+  encodeStealthMetaAddress: vi.fn(),
+  decodeStealthMetaAddress: vi.fn(),
+  fetchAnnouncements: vi.fn(),
+  fetchAnnouncementsStream: vi.fn(),
+  buildStealthPayment: vi.fn(),
+  getDeployment: vi.fn(() => ({
+    horizonUrl: 'https://horizon.test',
+    sorobanUrl: 'https://soroban.test',
+    contracts: { announcer: 'announcer', names: 'names' },
+  })),
+}));
+
+vi.mock('@stellar/stellar-sdk', () => ({
+  Horizon: {
+    Server: vi.fn().mockImplementation(() => ({
+      loadAccount: vi.fn().mockResolvedValue({
+        balances: [{ asset_type: 'native', balance: '10.5' }],
+      }),
+    })),
+  },
+}));
+
+describe('Stellar store parity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('matches the React key primitive and notifies the rendered subscriber', async () => {
+    const state = useStellarStealthKeys();
+    expect(state.keys).toBeDefined();
+    expect(state.generate).toBeTypeOf('function');
+
+    render(StoreHarness, {
+      props: {
+        value: state.keys,
+        run: () => state.generate(new Uint8Array([1, 2, 3])),
+      },
+    });
+
+    expect(screen.getByTestId('value').textContent).toContain('null');
+    await fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    expect(screen.getByTestId('value').textContent).toContain('generated');
+  });
+
+  it('scans announcements and updates scanning and announcement stores', async () => {
+    vi.mocked(fetchAnnouncementsStream).mockImplementation(async function* () {
+      await Promise.resolve();
+      yield { stealthAddress: 'GSTEALTH' } as never;
+    });
+    const state = useStellarAnnouncementScan();
+
+    render(StoreHarness, {
+      props: {
+        value: state.announcements,
+        run: () => state.scan({ fromLedger: 10 }),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Run' }));
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toContain('GSTEALTH'));
+    expect(get(state.scanning)).toBe(false);
+    expect(get(state.error)).toBeNull();
+  });
+
+  it('exposes building state while a payment is being built', async () => {
+    let finish!: (value: unknown) => void;
+    vi.mocked(buildStealthPayment).mockReturnValue(
+      new Promise((resolve) => {
+        finish = resolve;
+      }) as never,
+    );
+    const state = useStellarSendStealthPayment();
+
+    const pending = state.build({} as never);
+    expect(get(state.building)).toBe(true);
+    finish({ transaction: 'built' });
+    await expect(pending).resolves.toEqual({ transaction: 'built' });
+    expect(get(state.building)).toBe(false);
+  });
+
+  it('loads the native Stellar balance reactively', async () => {
+    const state = useStellarBalance('GACCOUNT', 'https://horizon.test');
+    render(StoreHarness, { props: { value: state.balance } });
+
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toContain('10.5'));
+    expect(get(state.loading)).toBe(false);
+  });
+
+  it('matches the React name primitive shape', () => {
+    const state = useStellarName(undefined);
+
+    expect(get(state.address)).toBeNull();
+    expect(get(state.loading)).toBe(false);
+    expect(get(state.error)).toBeNull();
+  });
+});

--- a/packages/sdk-svelte/test/useStellarStealthKeys.test.ts
+++ b/packages/sdk-svelte/test/useStellarStealthKeys.test.ts
@@ -28,7 +28,7 @@ vi.mock('@wraith-protocol/sdk/chains/stellar', () => ({
     spendingPubKey: new Uint8Array(32),
     viewingPubKey: new Uint8Array(32),
   }),
-  fetchAnnouncements: vi.fn().mockResolvedValue([]),
+  fetchAnnouncementsStream: vi.fn(),
 }));
 
 describe('useStellarStealthKeys', () => {

--- a/packages/sdk-svelte/tsup.config.ts
+++ b/packages/sdk-svelte/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     index: 'src/index.ts',
   },
   format: ['esm'],
-  dts: false,
+  dts: true,
   splitting: true,
   clean: true,
   treeshake: true,

--- a/packages/sdk-svelte/vitest.config.ts
+++ b/packages/sdk-svelte/vitest.config.ts
@@ -6,9 +6,10 @@ export default defineConfig({
   plugins: [svelte()],
   test: {
     globals: true,
-    environment: 'node',
+    environment: 'jsdom',
   },
   resolve: {
+    conditions: ['browser'],
     alias: {
       '@wraith-protocol/sdk': path.resolve(__dirname, '../../src'),
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,28 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  examples/stellar-svelte-receive:
+    dependencies:
+      '@stellar/stellar-sdk':
+        specifier: ^13.1.0
+        version: 13.3.0
+      '@wraith-protocol/sdk-svelte':
+        specifier: workspace:*
+        version: link:../../packages/sdk-svelte
+      svelte:
+        specifier: ^5.0.0
+        version: 5.56.4
+    devDependencies:
+      '@sveltejs/vite-plugin-svelte':
+        specifier: ^5.0.0
+        version: 5.1.1(svelte@5.56.4)(vite@6.4.3(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+
   examples/stellar-vue-receive:
     dependencies:
       '@wraith-protocol/sdk':
@@ -395,9 +417,18 @@ importers:
         specifier: workspace:*
         version: link:../..
     devDependencies:
+      '@stellar/stellar-sdk':
+        specifier: ^13.1.0
+        version: 13.3.0
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
         version: 5.1.1(svelte@5.56.4)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      '@testing-library/svelte':
+        specifier: ^5.2.0
+        version: 5.4.2(svelte@5.56.4)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       svelte:
         specifier: ^5.0.0
         version: 5.56.4
@@ -2315,79 +2346,66 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2585,6 +2603,25 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+
+  '@testing-library/svelte-core@1.1.3':
+    resolution: {integrity: sha512-KkMAvXeWorxN2Yn0kdC1lfoAItxpoj4uOWzxK5leDrNxonLvS5nwBFvztrroyTszQ0Wf/EU6iLT8JhY5qcn22g==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+
+  '@testing-library/svelte@5.4.2':
+    resolution: {integrity: sha512-4o31E4HGo5BU5KwPkulNRocEden+7Tt9JYm9uhln5ajF7DULeyFA46BBWVfKJ8Ms9B3JmOFPTIiVamH7n3KpuQ==}
+    engines: {node: '>= 10'}
+    peerDependencies:
+      svelte: ^3 || ^4 || ^5 || ^5.0.0-next.0
+      vite: '*'
+      vitest: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+      vitest:
+        optional: true
 
   '@types/argparse@1.0.38':
     resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
@@ -4842,28 +4879,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.19.0:
     resolution: {integrity: sha512-vSCKO7SDnZaFN9zEloKSZM5/kC5gbzUjoJQ43BvUpyTFUX7ACs/mDfl2Eq6fdz2+uWhUh7vf92c4EaaP4udEtA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.19.0:
     resolution: {integrity: sha512-0AFQKvVzXf9byrXUq9z0anMGLdZJS+XSDqidyijI5njIwj6MdbvX2UZK/c4FfNmeRa2N/8ngTffoIuOUit5eIQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.19.0:
     resolution: {integrity: sha512-SJoM8CLPt6ECCgSuWe+g0qo8dqQYVcPiW2s19dxkmSI5+Uu1GIRzyKA0b7QqmEXolA+oSJhQqCmJpzjY4CuZAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-x64-msvc@1.19.0:
     resolution: {integrity: sha512-C+VuUTeSUOAaBZZOPT7Etn/agx/MatzJzGRkeV+zEABmPuntv1zihncsi+AyGmjkkzq3wVedEy7h0/4S84mUtg==}
@@ -9705,6 +9738,19 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
+
+  '@testing-library/svelte-core@1.1.3(svelte@5.56.4)':
+    dependencies:
+      svelte: 5.56.4
+
+  '@testing-library/svelte@5.4.2(svelte@5.56.4)(vite@7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))(vitest@3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0))':
+    dependencies:
+      '@testing-library/dom': 9.3.4
+      '@testing-library/svelte-core': 1.1.3(svelte@5.56.4)
+      svelte: 5.56.4
+    optionalDependencies:
+      vite: 7.3.2(@types/node@25.6.0)(jiti@2.6.1)(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
+      vitest: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1(bufferutil@4.1.0)(utf-8-validate@6.0.6))(terser@5.48.0)(tsx@4.23.0)(yaml@2.9.0)
 
   '@types/argparse@1.0.38': {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
       '**/node_modules/**',
       '**/reference/**',
       '**/bench/**',
+      // Svelte component tests require the package-level compiler plugin and jsdom.
+      // The root test script runs this package separately with its own config.
+      'packages/sdk-svelte/test/**',
       // Vectors tests for non-Stellar chains reference fixtures that ship
       // only in future waves (packages/test-vectors/vectors/{ckb,evm,solana}.json).
       // Re-enable per chain when its fixture lands.


### PR DESCRIPTION
# sdk-svelte: parity with sdk-react hook set

## Summary

Brings the Stellar API in `@wraith-protocol/sdk-svelte` to parity with the
current `@wraith-protocol/sdk-react` hook set using idiomatic Svelte stores and
actions.

This also adds a Svelte 5 receive example that derives a Stellar stealth
meta-address and scans recent on-chain announcements.

## What changed

- Added `useStellarAnnouncementScan`
  - Exposes `announcements`, `scanning`, and `error` readable stores
  - Provides a `scan(options)` action backed by the core SDK's streaming
    announcement API
- Added `useStellarSendStealthPayment`
  - Exposes `building` and `error` readable stores
  - Provides a `build(options)` action
- Added `useStellarBalance`
  - Loads and exposes the native XLM balance through `balance` and `loading`
    stores
- Added `useStellarName`
  - Matches the React primitive's `address`, `loading`, and `error` shape
- Updated `useStellarStealthKeys`
  - Added the React-compatible `generate(signature)` action while preserving the
    existing `deriveKeys` action
  - Updated announcement fetching to use `fetchAnnouncementsStream`
- Exported all new primitives from the package entry point
- Enabled declaration generation so package consumers receive the updated public
  types
- Added `@testing-library/svelte` coverage with a rendered store subscriber to
  verify reactive updates
- Added `examples/stellar-svelte-receive`

## Public API parity

| React hook | Svelte primitive | State |
| --- | --- | --- |
| `useStellarStealthKeys` | `useStellarStealthKeys` | `keys`, `generate` |
| `useStellarAnnouncementScan` | `useStellarAnnouncementScan` | `announcements`, `scanning`, `error`, `scan` |
| `useStellarSendStealthPayment` | `useStellarSendStealthPayment` | `building`, `error`, `build` |
| `useStellarBalance` | `useStellarBalance` | `balance`, `loading` |
| `useStellarName` | `useStellarName` | `address`, `loading`, `error` |

All state fields are exposed as readable Svelte stores. Calling an action updates
the associated stores and notifies subscribers.

## Example

The new `stellar-svelte-receive` Vite app demonstrates:

1. Parsing a 64-byte hexadecimal secret
2. Deriving Stellar stealth keys
3. Generating a shareable stealth meta-address
4. Scanning the configured Stellar deployment for announcements
5. Rendering scan progress, results, and errors reactively

Run it with:

```bash
pnpm --filter @wraith-protocol/sdk-svelte build
pnpm --filter @wraith-protocol/example-stellar-svelte-receive dev
```

## Verification

- [x] `@wraith-protocol/sdk-svelte` tests pass: 10/10
- [x] Package typecheck passes
- [x] Package ESM and declaration builds pass
- [x] Example Svelte typecheck passes with no errors or warnings
- [x] Example production build passes
- [x] Vite dev server responds successfully and serves the compiled scan UI
- [x] Store writes notify rendered Svelte subscribers
- [x] Announcement scan state and results update reactively

## Scope

Changes are limited to `packages/sdk-svelte`, the new
`examples/stellar-svelte-receive` app, and the required workspace lockfile
updates. No core SDK or unrelated package source was changed.

closes #129