### PR TITLE
feat: add Stellar fee estimation with Horizon caching

### DIFF
--- a/src/chains/stellar/fee.ts
+++ b/src/chains/stellar/fee.ts
@@ -1,0 +1,167 @@
+/**
+ * Stellar fee estimation with caching.
+ *
+ * Estimates network fees for different operation types and urgency levels
+ * by pulling recent ledger data from Horizon's `/fee_stats` endpoint.
+ *
+ * @see {@link estimateFee}
+ */
+
+/**
+ * Stellar operation types supported for fee estimation.
+ *
+ * This is not exhaustive; it covers the common payment, asset, and contract operations.
+ */
+export type OperationKind =
+  | 'payment'
+  | 'manage_sell_offer'
+  | 'manage_buy_offer'
+  | 'path_payment_strict_receive'
+  | 'path_payment_strict_send'
+  | 'manage_data'
+  | 'bump_sequence'
+  | 'invoke_host_function'
+  | 'extend_footprint_ttl';
+
+/**
+ * Fee estimation urgency level.
+ *
+ * - `low`: Suitable for non-time-critical operations. Uses the 10th percentile.
+ * - `normal`: Recommended for most operations. Uses the median (50th percentile).
+ * - `high`: For time-critical operations during network congestion. Uses the 90th percentile.
+ */
+export type Urgency = 'low' | 'normal' | 'high';
+
+export interface FeeStats {
+  /** Ledger sequence number for this fee data. */
+  ledger: number;
+  /** Timestamp (ISO 8601) when this data was recorded. */
+  last_ledger_base_fee: string;
+  /** Fees in stroops for different percentiles. */
+  fee_charged: {
+    max: string;
+    min: string;
+    mode: string;
+    p10: string;
+    p20: string;
+    p30: string;
+    p40: string;
+    p50: string;
+    p60: string;
+    p70: string;
+    p80: string;
+    p90: string;
+    p99: string;
+  };
+  /** Max fees in stroops for different percentiles. */
+  max_fee: {
+    max: string;
+    min: string;
+    mode: string;
+    p10: string;
+    p20: string;
+    p30: string;
+    p40: string;
+    p50: string;
+    p60: string;
+    p70: string;
+    p80: string;
+    p90: string;
+    p99: string;
+  };
+}
+
+interface CacheEntry {
+  data: FeeStats;
+  timestamp: number;
+}
+
+const DEFAULT_TTL_MS = 30 * 1000; // 30 seconds
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Fetches fee stats from Horizon and caches them briefly.
+ *
+ * @param horizonUrl The Horizon API URL.
+ * @returns The fee statistics from Horizon.
+ * @throws If the Horizon request fails or returns invalid data.
+ */
+async function fetchFeeStats(horizonUrl: string): Promise<FeeStats> {
+  const now = Date.now();
+  const cached = cache.get(horizonUrl);
+
+  // Return cached data if still valid
+  if (cached && now - cached.timestamp < DEFAULT_TTL_MS) {
+    return cached.data;
+  }
+
+  const url = new URL('/fee_stats', horizonUrl).toString();
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    throw new Error(
+      `Horizon fee_stats request failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const data = (await response.json()) as FeeStats;
+
+  // Cache the result
+  cache.set(horizonUrl, { data, timestamp: now });
+
+  return data;
+}
+
+/**
+ * Estimates an inclusion fee in stroops for an operation type and urgency level.
+ *
+ * Fetches recent fee statistics from Horizon's `/fee_stats` endpoint and selects
+ * the appropriate percentile based on urgency. Results are cached for 30 seconds.
+ *
+ * @param opKind The Stellar operation type (e.g., 'payment', 'invoke_host_function').
+ * @param urgency The fee estimation urgency level ('low' | 'normal' | 'high').
+ * @param horizonUrl The Horizon API URL. Defaults to Stellar testnet.
+ * @returns The estimated fee per operation in stroops.
+ * @throws If the Horizon request fails.
+ *
+ * @example
+ * ```ts
+ * // Estimate a fee for a payment during normal network conditions
+ * const fee = await estimateFee('payment', 'normal');
+ * // → 1000 (stroops, or 0.0001 XLM)
+ *
+ * // High urgency during congestion
+ * const urgentFee = await estimateFee('invoke_host_function', 'high');
+ * // → 5000 (stroops)
+ * ```
+ */
+export async function estimateFee(
+  opKind: OperationKind,
+  urgency: Urgency = 'normal',
+  horizonUrl: string = 'https://horizon-testnet.stellar.org',
+): Promise<number> {
+  const stats = await fetchFeeStats(horizonUrl);
+
+  // Select percentile based on urgency
+  let percentile: keyof FeeStats['fee_charged'];
+  if (urgency === 'low') {
+    percentile = 'p10';
+  } else if (urgency === 'high') {
+    percentile = 'p90';
+  } else {
+    percentile = 'p50'; // normal
+  }
+
+  // Get the fee value and ensure it's at least 100 stroops (base fee)
+  const feeStr = stats.fee_charged[percentile];
+  const fee = Math.max(100, parseInt(feeStr, 10));
+
+  return fee;
+}
+
+/**
+ * Clears the fee stats cache for testing or manual cache invalidation.
+ */
+export function clearFeeCache(): void {
+  cache.clear();
+}

--- a/src/chains/stellar/index.ts
+++ b/src/chains/stellar/index.ts
@@ -80,6 +80,7 @@ export type {
 
 export { buildStellarSwapAndStealth } from './swap';
 export type { BuildStellarSwapAndStealthOptions, SwapAndStealthResult } from './swap';
+
 export { buildPathStealthPayment, findStrictReceivePath } from './path-payment';
 export type {
   BuildPathStealthPaymentOptions,
@@ -96,3 +97,6 @@ export { MemoValidationError, TEXT_MEMO_MAX_BYTES, HASH_MEMO_BYTES, ID_MEMO_MAX 
 
 export { createHorizonClient } from './horizon';
 export type { RetryPolicy, HorizonClient, HorizonClientConfig } from './horizon';
+
+export { estimateFee, clearFeeCache } from './fee';
+export type { OperationKind, Urgency, FeeStats } from './fee';

--- a/test/chains/stellar/fee.test.ts
+++ b/test/chains/stellar/fee.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Fee estimation tests.
+ *
+ * Unit tests use a mocked Horizon `/fee_stats` response.
+ * Integration tests (skipped by default) submit to futurenet.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { estimateFee, clearFeeCache, type FeeStats, type OperationKind } from '../../../src/chains/stellar/fee';
+
+const SKIP = process.env['INTEGRATION'] !== '1';
+
+// Mock fee stats response
+const mockFeeStats: FeeStats = {
+  ledger: 47889216,
+  last_ledger_base_fee: '100',
+  fee_charged: {
+    max: '10000',
+    min: '100',
+    mode: '500',
+    p10: '150',
+    p20: '300',
+    p30: '400',
+    p40: '600',
+    p50: '1000',
+    p60: '1200',
+    p70: '1500',
+    p80: '2000',
+    p90: '5000',
+    p99: '10000',
+  },
+  max_fee: {
+    max: '100000',
+    min: '1000',
+    mode: '5000',
+    p10: '1500',
+    p20: '3000',
+    p30: '4000',
+    p40: '6000',
+    p50: '10000',
+    p60: '12000',
+    p70: '15000',
+    p80: '20000',
+    p90: '50000',
+    p99: '100000',
+  },
+};
+
+describe('estimateFee', () => {
+  beforeEach(() => {
+    clearFeeCache();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    clearFeeCache();
+  });
+
+  test('returns p10 (low urgency)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => mockFeeStats,
+    })));
+
+    const fee = await estimateFee('payment', 'low');
+    expect(fee).toBe(150);
+  });
+
+  test('returns p50 (normal urgency)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => mockFeeStats,
+    })));
+
+    const fee = await estimateFee('payment', 'normal');
+    expect(fee).toBe(1000);
+  });
+
+  test('returns p90 (high urgency)', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => mockFeeStats,
+    })));
+
+    const fee = await estimateFee('payment', 'high');
+    expect(fee).toBe(5000);
+  });
+
+  test('enforces minimum fee of 100 stroops', async () => {
+    const lowStats = {
+      ...mockFeeStats,
+      fee_charged: {
+        ...mockFeeStats.fee_charged,
+        p10: '50', // Below minimum
+      },
+    };
+
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => lowStats,
+    })));
+
+    const fee = await estimateFee('payment', 'low');
+    expect(fee).toBe(100);
+  });
+
+  test('works with various operation kinds', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => mockFeeStats,
+    })));
+
+    const opKinds: OperationKind[] = [
+      'payment',
+      'manage_sell_offer',
+      'path_payment_strict_receive',
+      'invoke_host_function',
+    ];
+
+    for (const kind of opKinds) {
+      const fee = await estimateFee(kind, 'normal');
+      expect(fee).toBe(1000);
+    }
+  });
+
+  test('defaults to normal urgency', async () => {
+    vi.stubGlobal('fetch', async () => ({
+      ok: true,
+      json: async () => mockFeeStats,
+    }));
+
+    const fee = await estimateFee('payment');
+    expect(fee).toBe(1000);
+  });
+
+  test('caches results for 30 seconds', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => mockFeeStats,
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    // First call should fetch
+    const fee1 = await estimateFee('payment', 'normal', 'https://horizon-testnet.stellar.org');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second call should use cache
+    const fee2 = await estimateFee('payment', 'normal', 'https://horizon-testnet.stellar.org');
+    expect(fetchMock).toHaveBeenCalledTimes(1); // Still 1, not 2
+    expect(fee1).toBe(fee2);
+  });
+
+  test('caches per Horizon URL', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => mockFeeStats,
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    // Different URLs should make separate requests
+    await estimateFee('payment', 'normal', 'https://horizon-testnet.stellar.org');
+    await estimateFee('payment', 'normal', 'https://horizon.stellar.org');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('throws on failed Horizon request', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    })));
+
+    await expect(estimateFee('payment', 'normal')).rejects.toThrow(
+      'Horizon fee_stats request failed: 500 Internal Server Error',
+    );
+  });
+
+  test('throws on network error', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('Network error');
+    }));
+
+    await expect(estimateFee('payment', 'normal')).rejects.toThrow('Network error');
+  });
+
+  test('clears cache on clearFeeCache()', async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      json: async () => mockFeeStats,
+    }));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    // First call
+    await estimateFee('payment', 'normal', 'https://horizon-testnet.stellar.org');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Clear cache
+    clearFeeCache();
+
+    // Second call should fetch again
+    await estimateFee('payment', 'normal', 'https://horizon-testnet.stellar.org');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('Integration: estimateFee on futurenet', { skip: SKIP }, () => {
+  test('fetches real fee stats and returns positive stroops', async () => {
+    const futurenetUrl = 'https://horizon-futurenet.stellar.org';
+
+    const fee = await estimateFee('payment', 'normal', futurenetUrl);
+
+    expect(typeof fee).toBe('number');
+    expect(fee).toBeGreaterThanOrEqual(100);
+    expect(Number.isInteger(fee)).toBe(true);
+  });
+
+  test('high urgency fee is >= normal urgency fee', async () => {
+    const futurenetUrl = 'https://horizon-futurenet.stellar.org';
+
+    const normalFee = await estimateFee('payment', 'normal', futurenetUrl);
+    const highFee = await estimateFee('payment', 'high', futurenetUrl);
+
+    expect(highFee).toBeGreaterThanOrEqual(normalFee);
+  });
+});

--- a/test/chains/stellar/fee.test.ts
+++ b/test/chains/stellar/fee.test.ts
@@ -49,10 +49,11 @@ const mockFeeStats: FeeStats = {
 describe('estimateFee', () => {
   beforeEach(() => {
     clearFeeCache();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     clearFeeCache();
   });
 


### PR DESCRIPTION
closes #138 

- New estimateFee(opKind, urgency) function for stroops calculation
- Pulls fee stats from Horizon /fee_stats endpoint
- Caches results for 30 seconds with per-URL keying
- Supports urgency levels: low (p10), normal (p50), high (p90)
- Enforces minimum base fee of 100 stroops
- Comprehensive unit tests with mocked Horizon responses
- Optional integration test for futurenet
- Exported from Stellar chains module