### PR TITLE
feat(vault): WebAuthn-unlocked encrypted seed vault

### DIFF
--- a/src/vault/README.md
+++ b/src/vault/README.md
@@ -1,0 +1,124 @@
+# Seed Vault — Threat Model & Design
+
+The **SeedVault** encrypts a 32-byte stealth signing seed at rest in IndexedDB
+and requires a WebAuthn touch (biometric / PIN) to decrypt it. It is not a
+wallet and does not custody funds — its sole purpose is to remove the friction
+of having to sign the `STEALTH_SIGNING_MESSAGE` every session while keeping the
+derived seed off-disk in plaintext.
+
+---
+
+## What the vault protects
+
+| Threat                             | Mitigation                                                                                                                                                                                                   |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Plaintext seed on disk**         | The seed is encrypted with AES-256-GCM before it touches IndexedDB. The ciphertext is indistinguishable from random bytes.                                                                                   |
+| **Passive disk forensics**         | Even if an attacker dumps the IndexedDB file and obtains the encrypted blob, they cannot decrypt it without the WebAuthn PRF key material, which never leaves the secure enclave / TPM of the authenticator. |
+| **Unauthorised in-browser access** | The seed is held in a JavaScript `Uint8Array` in a private `Map`. There is no `localStorage`, `sessionStorage`, or `window` global leak.                                                                     |
+| **Cross-tab unlocking**            | When one tab locks the vault, all tabs that share the same `BroadcastChannel` name receive a `lock` event and wipe their in-memory seeds immediately.                                                        |
+| **Tab-close leakage**              | `pagehide` and `beforeunload` handlers clear the in-memory `Map` before the page unloads.                                                                                                                    |
+
+---
+
+## What the vault does **not** protect
+
+| Threat                                   | Reason                                                                                                                                                                                                                            |
+| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Compromised JavaScript context (XSS)** | If an attacker executes arbitrary JS in the same origin, they can call `vault.unlock()` and exfiltrate the seed (after the user touches their authenticator). This is an inherent limitation of _any_ browser-based secret store. |
+| **Memory scraping**                      | The seed resides in unencrypted `Uint8Array` memory while the vault is unlocked. A sophisticated memory-corruption exploit or OS-level process dump could recover it.                                                             |
+| **Authenticator compromise**             | If the user's platform authenticator (e.g. biometric sensor, PIN) is compromised, the attacker can perform WebAuthn assertions and decrypt the seed.                                                                              |
+| **Phishing / social engineering**        | The user can be tricked into touching their authenticator on a malicious origin. The vault assumes the origin is trusted.                                                                                                         |
+| **Backup & recovery**                    | The vault is a convenience layer. If the user's WebAuthn credential is deleted or the browser's IndexedDB is cleared, the seed is **irretrievable**. Users must back up their seed independently.                                 |
+| **Multi-device sync**                    | The vault is local to one browser profile on one device. It does not sync across devices.                                                                                                                                         |
+
+---
+
+## Cryptographic design
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        SEED VAULT CREATE                         │
+│                                                                  │
+│  1. Generate random 32-byte seed                                 │
+│  2. Generate random 32-byte PRF salt                             │
+│  3. WebAuthn create() with prf.eval.first = salt                 │
+│     → Authenticator returns prf.results.first = PRF(seed, salt)  │
+│     → Store credentialId                                         │
+│  4. PRF output → AES-256-GCM key                                 │
+│  5. Encrypt seed → { iv, ciphertext }                            │
+│  6. Store in IDB: { credentialId, salt, iv, ciphertext }         │
+└──────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────┐
+│                        SEED VAULT UNLOCK                         │
+│                                                                  │
+│  1. Read { credentialId, salt, iv, ciphertext } from IDB         │
+│  2. WebAuthn get() with prf.eval.first = salt                    │
+│     → Authenticator returns same PRF output                      │
+│  3. PRF output → AES-256-GCM key                                 │
+│  4. Decrypt → seed held in memory (JS Map)                       │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+- **PRF extension** (`prf`): defined in the WebAuthn Level 2 specification.
+  The authenticator computes `HMAC-SHA256(credential_private_key, salt)`.
+  The result is 32 bytes, suitable as AES-256 key material.
+- **AES-256-GCM**: each encryption uses a fresh 12-byte random IV.
+- **Salt uniqueness**: a random 32-byte salt is generated per vault entry.
+  The same salt is presented to the authenticator on every unlock.
+- **No PBKDF2**: the PRF output is used directly as the AES key (after
+  validation). There is no need for key stretching because the PRF output
+  already consumes the authenticator's private key.
+
+---
+
+## Data at rest (IndexedDB)
+
+The `entries` object store in the `wraith-seed-vault` database contains:
+
+| Field          | Type     | Description                                                      |
+| -------------- | -------- | ---------------------------------------------------------------- |
+| `label`        | `string` | Human-readable key (primary key).                                |
+| `credentialId` | `string` | Base64url-encoded WebAuthn credential ID.                        |
+| `salt`         | `string` | Base64-encoded 32-byte PRF salt.                                 |
+| `iv`           | `string` | Base64-encoded 12-byte AES-GCM IV.                               |
+| `ciphertext`   | `string` | Base64-encoded AES-256-GCM ciphertext (seed + 16-byte auth tag). |
+
+The ciphertext reveals no plaintext information. Without the WebAuthn
+authenticator and user presence, the entries are useless.
+
+---
+
+## Usage
+
+```ts
+import { SeedVault } from '@wraith-protocol/sdk/vault';
+
+if (!SeedVault.isSupported()) {
+  throw new Error('WebAuthn not available');
+}
+
+const vault = new SeedVault();
+
+// First time: register a credential and store the seed.
+const seed = await vault.create('my-stealth-seed');
+
+// Derive stealth keys from the seed as usual…
+// (After locking / tab-reload) — unlock again:
+await vault.unlock('my-stealth-seed');
+const seedAgain = vault.getSeed('my-stealth-seed');
+
+// Clean up when done.
+await vault.lock();
+```
+
+---
+
+## Non-goals
+
+- **Wallet / custody**: the vault does not broadcast transactions, sign
+  anything, or hold assets.
+- **Key manager**: it stores one 32-byte seed per label. It does not manage
+  hierarchical key trees or BIP-39 mnemonics.
+- **Multi-device sync**: there is no server component. Users must back up
+  their seed if they want to migrate to a new device.

--- a/src/vault/aes.ts
+++ b/src/vault/aes.ts
@@ -1,0 +1,73 @@
+/**
+ * Lightweight AES-256-GCM encrypt / decrypt wrappers backed by WebCrypto.
+ *
+ * All operations are in-memory; no plaintext touches persistent storage.
+ *
+ * @module vault/aes
+ */
+
+const AES_ALGORITHM = 'AES-GCM';
+const AES_KEY_LENGTH = 256;
+
+/**
+ * Import a raw 32-byte key into a WebCrypto {@link CryptoKey}.
+ *
+ * @param rawKey - 32 bytes of key material.
+ */
+export async function importAesKey(rawKey: Uint8Array): Promise<CryptoKey> {
+  if (rawKey.byteLength !== 32) {
+    throw new RangeError(`AES-256 key must be 32 bytes; got ${rawKey.byteLength}`);
+  }
+
+  return crypto.subtle.importKey('raw', rawKey as BufferSource, AES_ALGORITHM, false, [
+    'encrypt',
+    'decrypt',
+  ]);
+}
+
+/**
+ * Encrypt `plaintext` with AES-256-GCM.
+ *
+ * A fresh 12-byte IV is generated for every call.
+ *
+ * @param key   - An AES-256-GCM CryptoKey.
+ * @param plaintext - Arbitrary bytes to encrypt (e.g. seed material).
+ * @returns The random IV and resulting ciphertext (which includes the GCM
+ *          authentication tag).
+ */
+export async function aesEncrypt(
+  key: CryptoKey,
+  plaintext: Uint8Array,
+): Promise<{ iv: Uint8Array; ciphertext: Uint8Array }> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ct = await crypto.subtle.encrypt(
+    { name: AES_ALGORITHM, iv: iv as BufferSource },
+    key,
+    plaintext as BufferSource,
+  );
+  return { iv, ciphertext: new Uint8Array(ct) };
+}
+
+/**
+ * Decrypt `ciphertext` with AES-256-GCM.
+ *
+ * @param key        - An AES-256-GCM CryptoKey.
+ * @param iv         - The 12-byte IV used during encryption.
+ * @param ciphertext - The ciphertext + 16-byte authentication tag produced
+ *                     by {@link aesEncrypt}.
+ * @returns The original plaintext.
+ * @throws If the authentication tag does not match (tampered or corrupt
+ *         ciphertext).
+ */
+export async function aesDecrypt(
+  key: CryptoKey,
+  iv: Uint8Array,
+  ciphertext: Uint8Array,
+): Promise<Uint8Array> {
+  const pt = await crypto.subtle.decrypt(
+    { name: AES_ALGORITHM, iv: iv as BufferSource },
+    key,
+    ciphertext as BufferSource,
+  );
+  return new Uint8Array(pt);
+}

--- a/src/vault/index.ts
+++ b/src/vault/index.ts
@@ -1,0 +1,868 @@
+// ---------------------------------------------------------------------------
+// KeyVault — passphrase-based encrypted key-value store (existing)
+// ---------------------------------------------------------------------------
+
+const DB_NAME = 'wraith-vault';
+const DB_VERSION = 1;
+const STORE_META = 'meta';
+const STORE_ENTRIES = 'entries';
+const VAULT_META_KEY = 'vault';
+const DEFAULT_PBKDF2_ITERATIONS = 210_000;
+const DEFAULT_IDLE_LOCK_MS = 5 * 60 * 1000;
+
+export interface KeyVaultOptions {
+  dbName?: string;
+  iterations?: number;
+  idleTimeoutMs?: number | null;
+  lockOnBlur?: boolean;
+  lockOnVisibilityChange?: boolean;
+}
+
+interface VaultMetaRecord {
+  key: typeof VAULT_META_KEY;
+  salt: string;
+  checkIv: string;
+  checkCiphertext: string;
+  iterations: number;
+}
+
+interface VaultEntryRecord {
+  key: string;
+  iv: string;
+  ciphertext: string;
+}
+
+interface ResolvedOptions {
+  dbName: string;
+  iterations: number;
+  idleTimeoutMs: number | null;
+  lockOnBlur: boolean;
+  lockOnVisibilityChange: boolean;
+}
+
+function resolveOptions(options: KeyVaultOptions = {}): ResolvedOptions {
+  return {
+    dbName: options.dbName ?? DB_NAME,
+    iterations: options.iterations ?? DEFAULT_PBKDF2_ITERATIONS,
+    idleTimeoutMs:
+      options.idleTimeoutMs === undefined ? DEFAULT_IDLE_LOCK_MS : options.idleTimeoutMs,
+    lockOnBlur: options.lockOnBlur ?? true,
+    lockOnVisibilityChange: options.lockOnVisibilityChange ?? true,
+  };
+}
+
+function assertBrowserSupport(): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    throw new Error('KeyVault is browser-only and requires window and document.');
+  }
+  if (typeof indexedDB === 'undefined') {
+    throw new Error(
+      'KeyVault is browser-only and requires IndexedDB. Use the browser runtime or bundle.',
+    );
+  }
+  if (typeof crypto === 'undefined' || !crypto.subtle) {
+    throw new Error('KeyVault requires WebCrypto (crypto.subtle).');
+  }
+}
+
+function assertUnlocked(key: CryptoKey | null): asserts key is CryptoKey {
+  if (!key) {
+    throw new Error('KeyVault is locked. Call vault.unlock(passphrase) first.');
+  }
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function encodeValue(value: unknown): unknown {
+  if (value instanceof Uint8Array) {
+    return { __vaultType: 'Uint8Array', data: bytesToBase64(value) };
+  }
+
+  if (value instanceof ArrayBuffer) {
+    return { __vaultType: 'ArrayBuffer', data: bytesToBase64(new Uint8Array(value)) };
+  }
+
+  if (value instanceof Date) {
+    return { __vaultType: 'Date', data: value.toISOString() };
+  }
+
+  if (typeof value === 'bigint') {
+    return { __vaultType: 'bigint', data: value.toString() };
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => encodeValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      out[key] = encodeValue(item);
+    }
+    return out;
+  }
+
+  return value;
+}
+
+function decodeValue(value: unknown): unknown {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => decodeValue(item));
+  }
+
+  const record = value as Record<string, unknown>;
+  if (record.__vaultType === 'Uint8Array') {
+    return base64ToBytes(String(record.data));
+  }
+
+  if (record.__vaultType === 'ArrayBuffer') {
+    return base64ToBytes(String(record.data)).buffer;
+  }
+
+  if (record.__vaultType === 'Date') {
+    return new Date(String(record.data));
+  }
+
+  if (record.__vaultType === 'bigint') {
+    return BigInt(String(record.data));
+  }
+
+  const out: Record<string, unknown> = {};
+  for (const [key, item] of Object.entries(record)) {
+    if (key === '__vaultType') continue;
+    out[key] = decodeValue(item);
+  }
+  return out;
+}
+
+function toBytes(input: string): Uint8Array {
+  return new TextEncoder().encode(input);
+}
+
+async function deriveAesKey(
+  passphrase: string,
+  salt: Uint8Array,
+  iterations: number,
+): Promise<CryptoKey> {
+  const passphraseKey = await crypto.subtle.importKey(
+    'raw',
+    toBytes(passphrase) as BufferSource,
+    'PBKDF2',
+    false,
+    ['deriveKey'],
+  );
+
+  return crypto.subtle.deriveKey(
+    {
+      name: 'PBKDF2',
+      salt: salt as BufferSource,
+      iterations,
+      hash: 'SHA-256',
+    },
+    passphraseKey,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+async function encryptJson(
+  key: CryptoKey,
+  payload: unknown,
+): Promise<{ iv: string; ciphertext: string }> {
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const plaintext = toBytes(JSON.stringify(encodeValue(payload)));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv: iv as BufferSource },
+    key,
+    plaintext as BufferSource,
+  );
+  return { iv: bytesToBase64(iv), ciphertext: bytesToBase64(new Uint8Array(ciphertext)) };
+}
+
+async function decryptJson<T>(key: CryptoKey, iv: string, ciphertext: string): Promise<T> {
+  const plaintext = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: base64ToBytes(iv) as BufferSource },
+    key,
+    base64ToBytes(ciphertext) as BufferSource,
+  );
+  return decodeValue(JSON.parse(new TextDecoder().decode(plaintext))) as T;
+}
+
+export class KeyVault {
+  private readonly options: ResolvedOptions;
+  private dbPromise: Promise<IDBDatabase> | null = null;
+  private db: IDBDatabase | null = null;
+  private cryptoKey: CryptoKey | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly onActivity = () => this.resetIdleTimer();
+  private readonly onBlur = () => {
+    void this.lock();
+  };
+  private readonly onVisibilityChange = () => {
+    if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
+      void this.lock();
+    }
+  };
+
+  constructor(options: KeyVaultOptions = {}) {
+    assertBrowserSupport();
+    this.options = resolveOptions(options);
+  }
+
+  async unlock(passphrase: string): Promise<void> {
+    const db = await this.openDB();
+    const meta = await this.getMeta(db);
+    const resolvedMeta = meta ?? (await this.createMeta(db, passphrase, this.options.iterations));
+
+    const salt = base64ToBytes(resolvedMeta.salt);
+    const key = await deriveAesKey(passphrase, salt, resolvedMeta.iterations);
+
+    try {
+      await decryptJson<unknown>(key, resolvedMeta.checkIv, resolvedMeta.checkCiphertext);
+    } catch {
+      throw new Error(
+        'Unable to unlock KeyVault. The passphrase is incorrect or the vault is corrupt.',
+      );
+    }
+
+    this.cryptoKey = key;
+    this.installAutoLockHooks();
+    this.resetIdleTimer();
+  }
+
+  async lock(): Promise<void> {
+    this.cryptoKey = null;
+    this.clearIdleTimer();
+    this.removeAutoLockHooks();
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+      this.dbPromise = null;
+    }
+  }
+
+  async put<T>(label: string, keys: T): Promise<void> {
+    const key = this.cryptoKey;
+    assertUnlocked(key);
+    const db = await this.openDB();
+    const record = await encryptJson(key, keys);
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_ENTRIES, 'readwrite');
+      tx.objectStore(STORE_ENTRIES).put({
+        key: label,
+        iv: record.iv,
+        ciphertext: record.ciphertext,
+      } satisfies VaultEntryRecord);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+
+    this.resetIdleTimer();
+  }
+
+  async get<T>(label: string): Promise<T | null> {
+    const key = this.cryptoKey;
+    assertUnlocked(key);
+    const db = await this.openDB();
+    const record = await new Promise<VaultEntryRecord | null>((resolve, reject) => {
+      const tx = db.transaction(STORE_ENTRIES, 'readonly');
+      const req = tx.objectStore(STORE_ENTRIES).get(label);
+      req.onsuccess = () => resolve((req.result as VaultEntryRecord | undefined) ?? null);
+      req.onerror = () => reject(req.error);
+    });
+
+    if (!record) {
+      return null;
+    }
+
+    const value = await decryptJson<T>(key, record.iv, record.ciphertext);
+    this.resetIdleTimer();
+    return value;
+  }
+
+  private openDB(): Promise<IDBDatabase> {
+    if (this.dbPromise) {
+      return this.dbPromise;
+    }
+
+    this.dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(this.options.dbName, DB_VERSION);
+
+      req.onupgradeneeded = (evt) => {
+        const db = (evt.target as IDBOpenDBRequest).result;
+        if (db.objectStoreNames.contains(STORE_META)) {
+          db.deleteObjectStore(STORE_META);
+        }
+        if (db.objectStoreNames.contains(STORE_ENTRIES)) {
+          db.deleteObjectStore(STORE_ENTRIES);
+        }
+        db.createObjectStore(STORE_META, { keyPath: 'key' });
+        db.createObjectStore(STORE_ENTRIES, { keyPath: 'key' });
+      };
+
+      req.onsuccess = () => {
+        this.db = req.result;
+        this.db.onclose = () => {
+          if (this.db === req.result) {
+            this.db = null;
+            this.dbPromise = null;
+          }
+        };
+        resolve(req.result);
+      };
+      req.onerror = () => reject(req.error);
+    });
+
+    return this.dbPromise;
+  }
+
+  private async getMeta(db: IDBDatabase): Promise<VaultMetaRecord | null> {
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_META, 'readonly');
+      const req = tx.objectStore(STORE_META).get(VAULT_META_KEY);
+      req.onsuccess = () => resolve((req.result as VaultMetaRecord | undefined) ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  private async createMeta(
+    db: IDBDatabase,
+    passphrase: string,
+    iterations: number,
+  ): Promise<VaultMetaRecord> {
+    const salt = crypto.getRandomValues(new Uint8Array(16));
+    const key = await deriveAesKey(passphrase, salt, iterations);
+    const check = await encryptJson(key, { ok: true });
+    const meta: VaultMetaRecord = {
+      key: VAULT_META_KEY,
+      salt: bytesToBase64(salt),
+      checkIv: check.iv,
+      checkCiphertext: check.ciphertext,
+      iterations,
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(STORE_META, 'readwrite');
+      tx.objectStore(STORE_META).put(meta);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+
+    return meta;
+  }
+
+  private installAutoLockHooks(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.removeEventListener('pointerdown', this.onActivity);
+    window.removeEventListener('keydown', this.onActivity);
+    window.removeEventListener('scroll', this.onActivity);
+    window.removeEventListener('touchstart', this.onActivity);
+    window.removeEventListener('mousemove', this.onActivity);
+    window.removeEventListener('blur', this.onBlur);
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
+
+    if (this.options.idleTimeoutMs !== null) {
+      window.addEventListener('pointerdown', this.onActivity, { passive: true });
+      window.addEventListener('keydown', this.onActivity, { passive: true });
+      window.addEventListener('scroll', this.onActivity, { passive: true });
+      window.addEventListener('touchstart', this.onActivity, { passive: true });
+      window.addEventListener('mousemove', this.onActivity, { passive: true });
+    }
+
+    if (this.options.lockOnBlur) {
+      window.addEventListener('blur', this.onBlur);
+    }
+
+    if (this.options.lockOnVisibilityChange) {
+      document.addEventListener('visibilitychange', this.onVisibilityChange);
+    }
+  }
+
+  private removeAutoLockHooks(): void {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.removeEventListener('pointerdown', this.onActivity);
+    window.removeEventListener('keydown', this.onActivity);
+    window.removeEventListener('scroll', this.onActivity);
+    window.removeEventListener('touchstart', this.onActivity);
+    window.removeEventListener('mousemove', this.onActivity);
+    window.removeEventListener('blur', this.onBlur);
+    document.removeEventListener('visibilitychange', this.onVisibilityChange);
+  }
+
+  private resetIdleTimer(): void {
+    this.clearIdleTimer();
+    if (this.options.idleTimeoutMs === null || typeof window === 'undefined') {
+      return;
+    }
+
+    this.idleTimer = setTimeout(() => {
+      void this.lock();
+    }, this.options.idleTimeoutMs);
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SeedVault — WebAuthn-unlocked encrypted seed vault
+// ---------------------------------------------------------------------------
+
+import { aesEncrypt, aesDecrypt, importAesKey } from './aes';
+import { isWebAuthnSupported, createCredential, getAssertion } from './webauthn';
+
+const SEED_VAULT_DB_NAME = 'wraith-seed-vault';
+const SEED_VAULT_DB_VERSION = 1;
+const SEED_VAULT_STORE = 'entries';
+const SEED_VAULT_CHANNEL = 'wraith-seed-vault';
+const SEED_BYTE_LENGTH = 32;
+
+/** Message type for cross-tab coordination over BroadcastChannel. */
+type SeedVaultMessage = { type: 'lock' } | { type: 'lock-label'; label: string };
+
+interface SeedVaultEntry {
+  label: string;
+  credentialId: string;
+  salt: string;
+  iv: string;
+  ciphertext: string;
+}
+
+export interface SeedVaultOptions {
+  /** IndexedDB database name (default: `"wraith-seed-vault"`). */
+  dbName?: string;
+  /**
+   * BroadcastChannel name for cross-tab lock coordination.
+   * Set to `null` to disable cross-tab locking.
+   * (default: `"wraith-seed-vault"`).
+   */
+  channelName?: string | null;
+}
+
+export interface SeedVaultCreateOptions {
+  /** Relying Party id for WebAuthn (default: `"wraith-protocol"`). */
+  rpId?: string;
+  /** User display name shown in the browser UI. */
+  userName?: string;
+}
+
+export interface SeedVaultUnlockOptions {
+  /** Relying Party id for WebAuthn (must match the create call). */
+  rpId?: string;
+}
+
+function assertSeedVaultBrowser(): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    throw new Error('SeedVault is browser-only and requires window and document.');
+  }
+  if (typeof indexedDB === 'undefined') {
+    throw new Error('SeedVault is browser-only and requires IndexedDB.');
+  }
+  if (typeof crypto === 'undefined' || !crypto.subtle) {
+    throw new Error('SeedVault requires WebCrypto (crypto.subtle).');
+  }
+}
+
+/**
+ * WebAuthn-unlocked encrypted seed vault.
+ *
+ * Stores a 32-byte seed encrypted at rest in IndexedDB. The AES-256-GCM
+ * encryption key is derived from a WebAuthn PRF assertion, which means the
+ * user must touch their platform authenticator (Touch ID, Windows Hello, etc.)
+ * every time the vault is unlocked.
+ *
+ * **Cross-tab:** lock state is coordinated across tabs via BroadcastChannel.
+ * Locking in one tab locks all tabs. Tab-close also triggers a lock.
+ *
+ * **Not a wallet** — the SeedVault is for storing seed material only,
+ * not for custody of funds or transaction signing.
+ */
+export class SeedVault {
+  /** Check whether WebAuthn with PRF is available in the current browser. */
+  static isSupported(): boolean {
+    return isWebAuthnSupported();
+  }
+
+  private readonly dbName: string;
+  private readonly channel: BroadcastChannel | null;
+  private dbPromise: Promise<IDBDatabase> | null = null;
+  private db: IDBDatabase | null = null;
+  private readonly seeds = new Map<string, Uint8Array>();
+  private readonly onChannelMessage: (event: MessageEvent<SeedVaultMessage>) => void;
+  private readonly onPageHide: () => void;
+
+  constructor(options: SeedVaultOptions = {}) {
+    assertSeedVaultBrowser();
+    this.dbName = options.dbName ?? SEED_VAULT_DB_NAME;
+
+    const channelName =
+      options.channelName === undefined ? SEED_VAULT_CHANNEL : options.channelName;
+    this.channel =
+      typeof BroadcastChannel !== 'undefined' && channelName !== null
+        ? new BroadcastChannel(channelName)
+        : null;
+
+    this.onChannelMessage = (event: MessageEvent<SeedVaultMessage>) => {
+      if (event.data?.type === 'lock') {
+        this.lockSilent();
+      } else if (event.data?.type === 'lock-label') {
+        this.seeds.delete(event.data.label);
+      }
+    };
+
+    if (this.channel) {
+      this.channel.addEventListener('message', this.onChannelMessage);
+    }
+
+    this.onPageHide = () => {
+      this.lockSilent();
+    };
+
+    window.addEventListener('pagehide', this.onPageHide);
+    window.addEventListener('beforeunload', this.onPageHide);
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Create a new vault entry.
+   *
+   * Generates a random 32-byte seed, registers a WebAuthn credential with
+   * the PRF extension, encrypts the seed with the derived key, and persists
+   * the ciphertext to IndexedDB.
+   *
+   * The seed is **returned to the caller** so they can derive stealth keys
+   * immediately. It is also kept in the in-memory cache until {@link lock}
+   * is called.
+   *
+   * @param label   - Human-readable key for the entry.
+   * @param options - Optional WebAuthn configuration.
+   * @returns The 32-byte seed.
+   */
+  async create(label: string, options: SeedVaultCreateOptions = {}): Promise<Uint8Array> {
+    if (!isWebAuthnSupported()) {
+      throw new Error('WebAuthn is not supported in this browser.');
+    }
+
+    if (this.seeds.has(label)) {
+      throw new Error(`SeedVault entry "${label}" is already unlocked. Lock it first.`);
+    }
+
+    // Check whether a stored entry already exists under this label.
+    const existing = await this.getEntry(label);
+    if (existing) {
+      throw new Error(
+        `SeedVault entry "${label}" already exists. Use unlock() to access it or delete() to remove it.`,
+      );
+    }
+
+    const seed = crypto.getRandomValues(new Uint8Array(SEED_BYTE_LENGTH));
+    const salt = crypto.getRandomValues(new Uint8Array(32));
+
+    // Register WebAuthn credential and derive PRF key.
+    const { credentialId, prfKey } = await createCredential(salt, options.rpId, options.userName);
+
+    // Encrypt seed with PRF-derived AES key.
+    const aesKey = await importAesKey(prfKey);
+    const { iv, ciphertext } = await aesEncrypt(aesKey, seed);
+
+    // Persist to IndexedDB.
+    const entry: SeedVaultEntry = {
+      label,
+      credentialId,
+      salt: bytesToBase64(salt),
+      iv: bytesToBase64(iv),
+      ciphertext: bytesToBase64(ciphertext),
+    };
+
+    await this.putEntry(entry);
+
+    // Cache in memory.
+    this.seeds.set(label, seed);
+
+    return seed;
+  }
+
+  /**
+   * Unlock a vault entry by performing a WebAuthn assertion.
+   *
+   * The user will be prompted for a biometric or PIN touch. If the assertion
+   * succeeds, the PRF-derived key is used to decrypt the stored seed.
+   *
+   * @param label   - Label of the entry to unlock.
+   * @param options - Optional WebAuthn configuration.
+   * @returns The decrypted 32-byte seed.
+   */
+  async unlock(label: string, options: SeedVaultUnlockOptions = {}): Promise<Uint8Array> {
+    if (!isWebAuthnSupported()) {
+      throw new Error('WebAuthn is not supported in this browser.');
+    }
+
+    if (this.seeds.has(label)) {
+      return this.seeds.get(label)!;
+    }
+
+    const entry = await this.getEntry(label);
+    if (!entry) {
+      throw new Error(`SeedVault entry "${label}" not found. Use create() to create it first.`);
+    }
+
+    const salt = base64ToBytes(entry.salt);
+
+    // Perform WebAuthn assertion to recover PRF key.
+    const prfKey = await getAssertion(entry.credentialId, salt, options.rpId);
+
+    // Decrypt.
+    const aesKey = await importAesKey(prfKey);
+    const iv = base64ToBytes(entry.iv);
+    const ciphertext = base64ToBytes(entry.ciphertext);
+    const seed = await aesDecrypt(aesKey, iv, ciphertext);
+
+    // Validate seed length.
+    if (seed.byteLength !== SEED_BYTE_LENGTH) {
+      throw new Error(
+        `Decrypted seed has unexpected length ${seed.byteLength} (expected ${SEED_BYTE_LENGTH}). The vault may be corrupt.`,
+      );
+    }
+
+    this.seeds.set(label, seed);
+    return seed;
+  }
+
+  /**
+   * Return the in-memory seed for a label.
+   *
+   * @throws If the label has not been unlocked.
+   */
+  /**
+   * Return a **copy** of the in-memory seed for a label.
+   *
+   * The copy prevents accidental mutation of the cached value.
+   *
+   * @throws If the label has not been unlocked.
+   */
+  getSeed(label: string): Uint8Array {
+    const seed = this.seeds.get(label);
+    if (!seed) {
+      throw new Error(`SeedVault entry "${label}" is locked. Call vault.unlock("${label}") first.`);
+    }
+    return new Uint8Array(seed);
+  }
+
+  /** Whether the given label is currently unlocked. */
+  isUnlocked(label: string): boolean {
+    return this.seeds.has(label);
+  }
+
+  /** List all labels currently held in memory. */
+  get unlockedLabels(): string[] {
+    return Array.from(this.seeds.keys());
+  }
+
+  /**
+   * Lock the vault — wipe all in-memory seeds and broadcast the lock
+   * event to other tabs.
+   */
+  async lock(): Promise<void> {
+    this.seeds.clear();
+    this.closeDB();
+
+    if (this.channel) {
+      this.channel.postMessage({ type: 'lock' } satisfies SeedVaultMessage);
+    }
+  }
+
+  /**
+   * Lock a single label without affecting other unlocked entries.
+   * Broadcasts a targeted lock event so other tabs also drop the label.
+   */
+  lockLabel(label: string): void {
+    this.seeds.delete(label);
+
+    if (this.channel) {
+      this.channel.postMessage({ type: 'lock-label', label } satisfies SeedVaultMessage);
+    }
+  }
+
+  /**
+   * List all labels stored in IndexedDB (whether locked or not).
+   */
+  async listLabels(): Promise<string[]> {
+    const db = await this.openDB();
+
+    return new Promise<string[]>((resolve, reject) => {
+      const tx = db.transaction(SEED_VAULT_STORE, 'readonly');
+      const req = tx.objectStore(SEED_VAULT_STORE).getAllKeys();
+      req.onsuccess = () => resolve((req.result as string[]) ?? []);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  /**
+   * Delete a vault entry permanently from IndexedDB.
+   *
+   * The label does not need to be unlocked first.
+   */
+  async delete(label: string): Promise<void> {
+    this.seeds.delete(label);
+
+    const db = await this.openDB();
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(SEED_VAULT_STORE, 'readwrite');
+      tx.objectStore(SEED_VAULT_STORE).delete(label);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  /**
+   * Delete ALL vault entries and lock immediately.
+   *
+   * This is destructive and irreversible — the encrypted seeds cannot be
+   * recovered unless the user backed up the original seed material.
+   */
+  async destroy(): Promise<void> {
+    this.seeds.clear();
+
+    const db = await this.openDB();
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(SEED_VAULT_STORE, 'readwrite');
+      tx.objectStore(SEED_VAULT_STORE).clear();
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+
+    this.closeDB();
+
+    if (this.channel) {
+      this.channel.postMessage({ type: 'lock' } satisfies SeedVaultMessage);
+    }
+  }
+
+  /**
+   * Tear down the vault instance.
+   *
+   * Removes event listeners, closes BroadcastChannel and IndexedDB,
+   * and clears in-memory seeds. Call this when you no longer need the vault
+   * (e.g. component unmount).
+   */
+  destroyInstance(): void {
+    this.seeds.clear();
+    this.closeDB();
+
+    window.removeEventListener('pagehide', this.onPageHide);
+    window.removeEventListener('beforeunload', this.onPageHide);
+
+    if (this.channel) {
+      this.channel.removeEventListener('message', this.onChannelMessage);
+      this.channel.close();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal helpers
+  // -----------------------------------------------------------------------
+
+  private openDB(): Promise<IDBDatabase> {
+    if (this.dbPromise) {
+      return this.dbPromise;
+    }
+
+    this.dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(this.dbName, SEED_VAULT_DB_VERSION);
+
+      req.onupgradeneeded = (evt) => {
+        const db = (evt.target as IDBOpenDBRequest).result;
+        if (!db.objectStoreNames.contains(SEED_VAULT_STORE)) {
+          db.createObjectStore(SEED_VAULT_STORE, { keyPath: 'label' });
+        }
+      };
+
+      req.onsuccess = () => {
+        this.db = req.result;
+        this.db.onclose = () => {
+          if (this.db === req.result) {
+            this.db = null;
+            this.dbPromise = null;
+          }
+        };
+        resolve(req.result);
+      };
+      req.onerror = () => reject(req.error);
+    });
+
+    return this.dbPromise;
+  }
+
+  private closeDB(): void {
+    if (this.db) {
+      this.db.close();
+      this.db = null;
+      this.dbPromise = null;
+    }
+  }
+
+  private async getEntry(label: string): Promise<SeedVaultEntry | null> {
+    const db = await this.openDB();
+
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(SEED_VAULT_STORE, 'readonly');
+      const req = tx.objectStore(SEED_VAULT_STORE).get(label);
+      req.onsuccess = () => resolve((req.result as SeedVaultEntry | undefined) ?? null);
+      req.onerror = () => reject(req.error);
+    });
+  }
+
+  private async putEntry(entry: SeedVaultEntry): Promise<void> {
+    const db = await this.openDB();
+
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(SEED_VAULT_STORE, 'readwrite');
+      tx.objectStore(SEED_VAULT_STORE).put(entry);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+
+  private lockSilent(): void {
+    this.seeds.clear();
+    // Do NOT close IDB on pagehide — the browser is tearing down anyway
+    // and closing can cause "blocked" errors during navigation.
+  }
+}

--- a/src/vault/webauthn.ts
+++ b/src/vault/webauthn.ts
@@ -1,0 +1,231 @@
+/**
+ * WebAuthn helpers for the Wraith Seed Vault.
+ *
+ * Uses the WebAuthn **PRF** extension (`prf`) to derive a deterministic
+ * 32-byte symmetric key from a platform or cross-platform authenticator.
+ * That key encrypts the user's stealth signing seed via AES-256-GCM so the
+ * seed never leaves the browser in plaintext.
+ *
+ * **Browser support:** Chrome 116+, Edge 116+, and any browser implementing
+ * the WebAuthn Level 3 PRF extension. Call {@link isWebAuthnSupported} before
+ * invoking the other helpers.
+ *
+ * @module vault/webauthn
+ */
+
+/**
+ * Default origin-agnostic relying-party identifier.
+ *
+ * Callers SHOULD override this with a domain-scoped RP id (e.g.
+ * `"login.example.com"`) in production so credentials remain valid across
+ * subdomains if needed.
+ */
+const DEFAULT_RP_ID = 'wraith-protocol';
+
+const DEFAULT_RP_NAME = 'Wraith Protocol';
+
+/**
+ * Returns `true` when the current browser supports WebAuthn **and** the PRF
+ * extension.
+ *
+ * This is the gate check — if it returns `false`, {@link createCredential}
+ * and {@link getAssertion} will reject.
+ */
+export function isWebAuthnSupported(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.PublicKeyCredential !== 'undefined' &&
+    typeof PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable === 'function'
+  );
+}
+
+/**
+ * Check whether a platform authenticator (Touch ID, Windows Hello, etc.) is
+ * available on the current device.
+ *
+ * Callers can use this to decide whether to show a "create vault" button
+ * before the user goes through the WebAuthn flow. If this returns `false`,
+ * the user only has cross-platform authenticators (e.g. USB security keys)
+ * available.
+ *
+ * Returns `null` when `isWebAuthnSupported() === false` (i.e. the browser
+ * does not support WebAuthn at all).
+ */
+export async function isPlatformAuthenticatorAvailable(): Promise<boolean | null> {
+  if (!isWebAuthnSupported()) return null;
+  return PublicKeyCredential.isUserVerifyingPlatformAuthenticatorAvailable();
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function base64UrlEncode(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64UrlDecode(base64url: string): Uint8Array {
+  const padded = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Extract the 32-byte PRF result from a credential response.
+ *
+ * The PRF extension is not defined in the standard TypeScript DOM types but
+ * is available at runtime in supporting browsers.
+ */
+function extractPrfResult(
+  response: AuthenticatorAttestationResponse | AuthenticatorAssertionResponse,
+): Uint8Array {
+  const ext = (response as any).getClientExtensionResults?.() as
+    { prf?: { enabled?: boolean; results?: { first?: ArrayBuffer } } } | undefined;
+
+  if (!ext?.prf?.enabled || !ext.prf.results?.first) {
+    throw new Error(
+      'WebAuthn PRF extension is not supported by this authenticator. ' +
+        'Try a different device or browser.',
+    );
+  }
+
+  return new Uint8Array(ext.prf.results.first);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface CreateCredentialResult {
+  /** Base64url-encoded credential ID — store this for later assertions. */
+  credentialId: string;
+  /** 32-byte PRF output — the AES-256 key material. */
+  prfKey: Uint8Array;
+}
+
+/**
+ * Register a new WebAuthn credential and derive a 32-byte PRF key.
+ *
+ * The PRF salt is echoed in the `prf.eval.first` extension field so the
+ * authenticator can compute `HMAC-SHA256(credentialPrivateKey, salt)`.
+ * The same salt must be supplied to {@link getAssertion} to recover the
+ * same key.
+ *
+ * **User experience:** the browser will prompt for a biometric or PIN touch.
+ *
+ * @param salt         - 32-byte PRF evaluation salt (MUST be random and
+ *                       stored alongside the encrypted seed).
+ * @param rpId         - Relying Party id (defaults to `"wraith-protocol"`).
+ * @param userName     - Display name shown in the browser UI.
+ * @returns The credential ID and derived 32-byte PRF key.
+ */
+export async function createCredential(
+  salt: Uint8Array,
+  rpId = DEFAULT_RP_ID,
+  userName = 'Wraith Seed Vault',
+): Promise<CreateCredentialResult> {
+  if (!isWebAuthnSupported()) {
+    throw new Error('WebAuthn is not supported in this browser.');
+  }
+
+  if (salt.byteLength !== 32) {
+    throw new RangeError(`PRF salt must be 32 bytes; got ${salt.byteLength}`);
+  }
+
+  const userId = crypto.getRandomValues(new Uint8Array(16));
+
+  const credential = (await navigator.credentials.create({
+    publicKey: {
+      rp: { id: rpId, name: DEFAULT_RP_NAME },
+      user: {
+        id: userId as BufferSource,
+        name: userName,
+        displayName: userName,
+      },
+      challenge: crypto.getRandomValues(new Uint8Array(32)) as BufferSource,
+      pubKeyCredParams: [
+        { type: 'public-key', alg: -7 }, // ES256
+        { type: 'public-key', alg: -257 }, // RS256
+      ],
+      authenticatorSelection: {
+        authenticatorAttachment: 'platform',
+        userVerification: 'required',
+        residentKey: 'required',
+      },
+      extensions: {
+        prf: { eval: { first: salt.buffer as ArrayBuffer } },
+      } as any,
+    },
+  })) as PublicKeyCredential | null;
+
+  if (!credential) {
+    throw new Error('WebAuthn credential creation was cancelled or failed.');
+  }
+
+  const prfKey = extractPrfResult(credential.response as AuthenticatorAttestationResponse);
+
+  return {
+    credentialId: base64UrlEncode(credential.rawId),
+    prfKey,
+  };
+}
+
+/**
+ * Perform a WebAuthn assertion (biometric / PIN touch) and recover the
+ * 32-byte PRF key.
+ *
+ * @param credentialId - Base64url-encoded credential ID returned by
+ *                       {@link createCredential}.
+ * @param salt         - The same 32-byte salt that was supplied to
+ *                       {@link createCredential}.
+ * @param rpId         - Relying Party id (must match the creation call).
+ * @returns The recovered 32-byte PRF key.
+ */
+export async function getAssertion(
+  credentialId: string,
+  salt: Uint8Array,
+  rpId = DEFAULT_RP_ID,
+): Promise<Uint8Array> {
+  if (!isWebAuthnSupported()) {
+    throw new Error('WebAuthn is not supported in this browser.');
+  }
+
+  if (salt.byteLength !== 32) {
+    throw new RangeError(`PRF salt must be 32 bytes; got ${salt.byteLength}`);
+  }
+
+  const idBytes = base64UrlDecode(credentialId);
+
+  const assertion = (await navigator.credentials.get({
+    publicKey: {
+      rpId,
+      challenge: crypto.getRandomValues(new Uint8Array(32)) as BufferSource,
+      allowCredentials: [
+        {
+          id: idBytes as BufferSource,
+          type: 'public-key',
+        },
+      ],
+      userVerification: 'required',
+      extensions: {
+        prf: { eval: { first: salt.buffer as ArrayBuffer } },
+      } as any,
+    },
+  })) as PublicKeyCredential | null;
+
+  if (!assertion) {
+    throw new Error('WebAuthn assertion was cancelled or failed.');
+  }
+
+  return extractPrfResult(assertion.response as AuthenticatorAssertionResponse);
+}

--- a/test/vault/seed-vault.test.ts
+++ b/test/vault/seed-vault.test.ts
@@ -1,0 +1,460 @@
+/**
+ * SeedVault test suite.
+ *
+ * WebAuthn is fully mocked so tests run in Node without a browser.
+ * The WebCrypto (AES-GCM) and fake-indexeddb layers are real.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { IDBFactory, IDBKeyRange } from 'fake-indexeddb';
+import { SeedVault } from '../../src/vault';
+
+// ---------------------------------------------------------------------------
+// WebAuthn mock helpers
+// ---------------------------------------------------------------------------
+
+function createMockPublicKeyCredential() {
+  const ctor = vi.fn() as any;
+  ctor.isUserVerifyingPlatformAuthenticatorAvailable = vi.fn().mockResolvedValue(true);
+  return ctor;
+}
+
+function installWebAuthnMock() {
+  if (typeof navigator === 'undefined') {
+    (globalThis as any).navigator = {};
+  }
+
+  const nav = globalThis.navigator as any;
+
+  nav.credentials = {
+    create: vi.fn().mockImplementation(async (opts: any) => {
+      const evalFirst = opts?.publicKey?.extensions?.prf?.eval?.first;
+      const salt = evalFirst ? new Uint8Array(evalFirst) : new Uint8Array(32);
+      // Compute deterministic PRF output for this salt.
+      const hash = await crypto.subtle.digest('SHA-256', salt);
+      const prfBytes = new Uint8Array(hash);
+      const getClientExtensionResults = () => ({
+        prf: { enabled: true, results: { first: prfBytes.buffer.slice(0) } },
+      });
+
+      const rawId = crypto.getRandomValues(new Uint8Array(32));
+      return {
+        type: 'public-key',
+        id: btoa(String.fromCharCode(...rawId)),
+        rawId: rawId.buffer,
+        response: { getClientExtensionResults },
+        getClientExtensionResults,
+      };
+    }),
+
+    get: vi.fn().mockImplementation(async (opts: any) => {
+      const evalFirst = opts?.publicKey?.extensions?.prf?.eval?.first;
+      const salt = evalFirst ? new Uint8Array(evalFirst) : new Uint8Array(32);
+      const hash = await crypto.subtle.digest('SHA-256', salt);
+      const prfBytes = new Uint8Array(hash);
+      const getClientExtensionResults = () => ({
+        prf: { enabled: true, results: { first: prfBytes.buffer.slice(0) } },
+      });
+
+      return {
+        type: 'public-key',
+        id: 'mock-assertion',
+        rawId: new Uint8Array(16).buffer,
+        response: { getClientExtensionResults },
+        getClientExtensionResults,
+      };
+    }),
+  };
+
+  const MockPKC = createMockPublicKeyCredential();
+
+  // Set on globalThis (for `typeof PublicKeyCredential` checks).
+  (globalThis as any).PublicKeyCredential = MockPKC;
+
+  // Set on window mock (for `window.PublicKeyCredential` checks).
+  const win = (globalThis as any).window;
+  if (win) {
+    win.PublicKeyCredential = MockPKC;
+  }
+}
+
+/** Create a BroadcastChannel mock that captures listeners and messages. */
+function createBroadcastChannelMock() {
+  const listeners = new Map<string, Set<EventListener>>();
+  const messages: any[] = [];
+
+  const channel = {
+    addEventListener(type: string, listener: EventListener) {
+      let set = listeners.get(type);
+      if (!set) {
+        set = new Set();
+        listeners.set(type, set);
+      }
+      set.add(listener);
+    },
+    removeEventListener(type: string, listener: EventListener) {
+      listeners.get(type)?.delete(listener);
+    },
+    postMessage(data: any) {
+      messages.push(data);
+      // Deliver to listeners on the SAME channel (simulating cross-tab delivery).
+      for (const listener of listeners.get('message') ?? []) {
+        listener(new MessageEvent('message', { data }));
+      }
+    },
+    close: vi.fn(),
+    _listeners: listeners,
+  };
+
+  (globalThis as any).BroadcastChannel = vi.fn().mockImplementation(() => channel);
+  return channel;
+}
+
+function removeWebAuthnMock() {
+  delete (globalThis as any).PublicKeyCredential;
+  delete (globalThis as any).BroadcastChannel;
+
+  const win = (globalThis as any).window;
+  if (win) {
+    delete win.PublicKeyCredential;
+  }
+
+  const nav = globalThis.navigator as any;
+  if (nav) {
+    delete nav.credentials;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test environment polyfills
+// ---------------------------------------------------------------------------
+
+function installBrowserPolyfills() {
+  if (typeof window === 'undefined') {
+    (globalThis as any).window = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      PublicKeyCredential: undefined,
+    };
+  }
+  if (typeof document === 'undefined') {
+    (globalThis as any).document = {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      visibilityState: 'visible',
+    };
+  }
+}
+
+function removeBrowserPolyfills() {
+  // Keep window/document if they were defined before tests — safe to leave.
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SeedVault', () => {
+  const originalIndexedDB = globalThis.indexedDB;
+  const originalIDBKeyRange = globalThis.IDBKeyRange;
+
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+    globalThis.IDBKeyRange = IDBKeyRange;
+    installBrowserPolyfills();
+    installWebAuthnMock();
+  });
+
+  afterEach(() => {
+    globalThis.indexedDB = originalIndexedDB;
+    globalThis.IDBKeyRange = originalIDBKeyRange;
+    removeWebAuthnMock();
+    removeBrowserPolyfills();
+  });
+
+  // -------------------------------------------------------------------
+  // Static checks
+  // -------------------------------------------------------------------
+
+  describe('isSupported', () => {
+    it('returns true when WebAuthn is available', () => {
+      expect(SeedVault.isSupported()).toBe(true);
+    });
+
+    it('returns false when WebAuthn is absent', () => {
+      const savedGlobal = (globalThis as any).PublicKeyCredential;
+      const win = (globalThis as any).window;
+
+      delete (globalThis as any).PublicKeyCredential;
+      if (win) delete win.PublicKeyCredential;
+
+      expect(SeedVault.isSupported()).toBe(false);
+
+      (globalThis as any).PublicKeyCredential = savedGlobal;
+      if (win) win.PublicKeyCredential = savedGlobal;
+    });
+
+    it('returns false when not in a browser', () => {
+      const savedWindow = (globalThis as any).window;
+      const savedPKC = (globalThis as any).PublicKeyCredential;
+
+      delete (globalThis as any).window;
+      delete (globalThis as any).PublicKeyCredential;
+
+      expect(SeedVault.isSupported()).toBe(false);
+
+      (globalThis as any).window = savedWindow;
+      (globalThis as any).PublicKeyCredential = savedPKC;
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Round-trip: create → lock → unlock
+  // -------------------------------------------------------------------
+
+  describe('round-trip', () => {
+    it('create → lock → unlock recovers identical seed', async () => {
+      const vault = new SeedVault({ dbName: 'test-roundtrip', channelName: null });
+      const seed1 = await vault.create('primary');
+
+      expect(seed1).toBeInstanceOf(Uint8Array);
+      expect(seed1.byteLength).toBe(32);
+
+      // Seed should be in memory after create.
+      expect(vault.isUnlocked('primary')).toBe(true);
+      expect(vault.getSeed('primary')).toEqual(seed1);
+
+      // getSeed returns a copy, not the live buffer.
+      const copy = vault.getSeed('primary');
+      copy[0] = 0xff;
+      expect(vault.getSeed('primary')).toEqual(seed1);
+
+      await vault.lock();
+      expect(vault.isUnlocked('primary')).toBe(false);
+      expect(() => vault.getSeed('primary')).toThrow('locked');
+
+      const seed2 = await vault.unlock('primary');
+      expect(seed2).toEqual(seed1);
+      expect(seed2).toBeInstanceOf(Uint8Array);
+      expect(vault.isUnlocked('primary')).toBe(true);
+    });
+
+    it('create → destroyInstance → unlock recovers identical seed', async () => {
+      const vault = new SeedVault({ dbName: 'test-persist', channelName: null });
+      const seed1 = await vault.create('primary');
+
+      vault.destroyInstance();
+
+      const vault2 = new SeedVault({ dbName: 'test-persist', channelName: null });
+      expect(vault2.isUnlocked('primary')).toBe(false);
+      const seed2 = await vault2.unlock('primary');
+      expect(seed2).toEqual(seed1);
+      vault2.destroyInstance();
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Cross-tab coordination (BroadcastChannel)
+  // -------------------------------------------------------------------
+
+  describe('cross-tab', () => {
+    it('lock broadcasts to other tabs and wipes local seeds', async () => {
+      const channel = createBroadcastChannelMock();
+
+      const vaultA = new SeedVault({ dbName: 'test-cross-tab', channelName: 'test-channel' });
+      await vaultA.create('secret');
+      expect(vaultA.isUnlocked('secret')).toBe(true);
+
+      // Simulate another tab locking.
+      channel.postMessage({ type: 'lock' });
+
+      // Vault A should have received the message and locked.
+      expect(vaultA.isUnlocked('secret')).toBe(false);
+    });
+
+    it('lockLabel broadcasts targeted lock', async () => {
+      const channel = createBroadcastChannelMock();
+
+      const vaultA = new SeedVault({ dbName: 'test-cross-tab-label', channelName: 'test-channel' });
+      await vaultA.create('alpha');
+      await vaultA.create('beta');
+
+      // Simulate another tab locking just 'alpha'.
+      channel.postMessage({ type: 'lock-label', label: 'alpha' });
+
+      expect(vaultA.isUnlocked('alpha')).toBe(false);
+      expect(vaultA.isUnlocked('beta')).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // List labels
+  // -------------------------------------------------------------------
+
+  describe('listLabels', () => {
+    it('lists stored labels even when locked', async () => {
+      const vault = new SeedVault({ dbName: 'test-list', channelName: null });
+      await vault.create('alpha');
+      await vault.create('beta');
+      await vault.lock();
+
+      const labels = await vault.listLabels();
+      expect(labels).toContain('alpha');
+      expect(labels).toContain('beta');
+      expect(labels.length).toBe(2);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Unlock errors
+  // -------------------------------------------------------------------
+
+  describe('unlock errors', () => {
+    it('throws when entry does not exist', async () => {
+      const vault = new SeedVault({ dbName: 'test-no-entry', channelName: null });
+      await expect(vault.unlock('nope')).rejects.toThrow('not found');
+    });
+
+    it('throws when WebAuthn is not supported', async () => {
+      const savedGlobal = (globalThis as any).PublicKeyCredential;
+      const win = (globalThis as any).window;
+
+      delete (globalThis as any).PublicKeyCredential;
+      if (win) delete win.PublicKeyCredential;
+
+      const vault = new SeedVault({ dbName: 'test-no-webauthn', channelName: null });
+      await expect(vault.create('primary')).rejects.toThrow('WebAuthn is not supported');
+
+      (globalThis as any).PublicKeyCredential = savedGlobal;
+      if (win) win.PublicKeyCredential = savedGlobal;
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Lock & lockLabel
+  // -------------------------------------------------------------------
+
+  describe('lock controls', () => {
+    it('lockLabel locks only the specified label', async () => {
+      const vault = new SeedVault({ dbName: 'test-lock-label', channelName: null });
+      await vault.create('a');
+      await vault.create('b');
+
+      vault.lockLabel('a');
+      expect(vault.isUnlocked('a')).toBe(false);
+      expect(vault.isUnlocked('b')).toBe(true);
+
+      await vault.lock();
+    });
+
+    it('lock locks all labels', async () => {
+      const vault = new SeedVault({ dbName: 'test-lock-all', channelName: null });
+      await vault.create('a');
+      await vault.create('b');
+      await vault.lock();
+
+      expect(vault.isUnlocked('a')).toBe(false);
+      expect(vault.isUnlocked('b')).toBe(false);
+    });
+
+    it('unlockedLabels reflects current state', async () => {
+      const vault = new SeedVault({ dbName: 'test-labels-list', channelName: null });
+      await vault.create('x');
+      await vault.create('y');
+
+      expect(vault.unlockedLabels).toContain('x');
+      expect(vault.unlockedLabels).toContain('y');
+
+      vault.lockLabel('x');
+      expect(vault.unlockedLabels).not.toContain('x');
+      expect(vault.unlockedLabels).toContain('y');
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Delete
+  // -------------------------------------------------------------------
+
+  describe('delete', () => {
+    it('removes entry and cannot be unlocked afterwards', async () => {
+      const vault = new SeedVault({ dbName: 'test-delete', channelName: null });
+      await vault.create('temp');
+      await vault.delete('temp');
+
+      expect(vault.isUnlocked('temp')).toBe(false);
+      await expect(vault.unlock('temp')).rejects.toThrow('not found');
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // destroy
+  // -------------------------------------------------------------------
+
+  describe('destroy', () => {
+    it('clears all entries', async () => {
+      const vault = new SeedVault({ dbName: 'test-destroy', channelName: null });
+      await vault.create('one');
+      await vault.create('two');
+
+      await vault.destroy();
+      expect(vault.isUnlocked('one')).toBe(false);
+      expect(vault.isUnlocked('two')).toBe(false);
+
+      const labels = await vault.listLabels();
+      expect(labels.length).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Non-browser rejection
+  // -------------------------------------------------------------------
+
+  describe('browser-only guard', () => {
+    it('rejects construction without window', () => {
+      const savedWindow = (globalThis as any).window;
+      const savedDocument = (globalThis as any).document;
+      const savedIndexedDB = (globalThis as any).indexedDB;
+
+      delete (globalThis as any).window;
+      delete (globalThis as any).document;
+      delete (globalThis as any).indexedDB;
+
+      expect(() => new SeedVault()).toThrow('SeedVault is browser-only');
+
+      (globalThis as any).window = savedWindow;
+      (globalThis as any).document = savedDocument;
+      (globalThis as any).indexedDB = savedIndexedDB;
+    });
+
+    it('rejects construction without IndexedDB', () => {
+      const savedIndexedDB = (globalThis as any).indexedDB;
+      delete (globalThis as any).indexedDB;
+      expect(() => new SeedVault()).toThrow('SeedVault is browser-only');
+      (globalThis as any).indexedDB = savedIndexedDB;
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // Duplicate create guard
+  // -------------------------------------------------------------------
+
+  describe('duplicate guard', () => {
+    it('rejects create when label already exists in IDB', async () => {
+      const vault = new SeedVault({ dbName: 'test-dup', channelName: null });
+      await vault.create('primary');
+      await vault.lock();
+
+      await expect(vault.create('primary')).rejects.toThrow('already exists');
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // getSeed error
+  // -------------------------------------------------------------------
+
+  describe('getSeed', () => {
+    it('throws descriptive error when locked', () => {
+      const vault = new SeedVault({ dbName: 'test-getseed', channelName: null });
+      expect(() => vault.getSeed('nope')).toThrow('locked');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the WebAuthn-unlocked `SeedVault` described in #134.

Users can now store their `STEALTH_SIGNING_MESSAGE` derivation seed encrypted at rest and unlock it with a single biometric/PIN touch — eliminating the need to sign a wallet message every session.

## What's in this PR

### `src/vault/aes.ts` (new)
Minimal AES-256-GCM encrypt/decrypt wrappers backed by WebCrypto. Fresh 12-byte IV per operation; no plaintext ever leaves memory.

### `src/vault/webauthn.ts` (new)
WebAuthn PRF-extension helpers:
- `createCredential(salt, rpId, userName)` — registers a platform authenticator credential and returns a 32-byte PRF key
- `getAssertion(credentialId, salt, rpId)` — performs a biometric/PIN assertion and recovers the same 32-byte PRF key
- `isWebAuthnSupported()` / `isPlatformAuthenticatorAvailable()` — browser-support guards

### `src/vault/index.ts` (extended)
`SeedVault` class added alongside the existing `KeyVault`:
- `create(label)` — generates a random 32-byte seed, registers a WebAuthn credential, encrypts seed with PRF-derived AES key, persists ciphertext to IndexedDB
- `unlock(label)` — WebAuthn assertion → PRF key → AES decrypt → seed held in JS `Map`
- `lock()` / `lockLabel(label)` — wipes in-memory seeds; broadcasts to other tabs via `BroadcastChannel`
- `getSeed(label)` — returns a **copy** of the in-memory seed (prevents accidental mutation)
- `listLabels()` / `delete(label)` / `destroy()` / `destroyInstance()`
- `pagehide` + `beforeunload` handlers wipe seeds on tab close
- `SeedVault.isSupported()` static check

### `src/vault/README.md` (new)
Threat-model document covering:
- What the vault **does** protect (disk forensics, cross-tab unlock, tab-close leakage, passive observation)
- What the vault **does not** protect (XSS, memory scraping, authenticator compromise, phishing)
- Cryptographic design diagram (create + unlock flows)
- Data-at-rest schema (IndexedDB fields)
- Non-goals: not a wallet, not a key manager, no multi-device sync

### `test/vault/seed-vault.test.ts` (new)
19 tests covering:
- `isSupported` (3 cases: available, absent, non-browser)
- Round-trip: `create → lock → unlock` recovers identical seed; `getSeed` returns copies
- Persistence: `create → destroyInstance → new SeedVault → unlock` recovers seed
- Cross-tab: `BroadcastChannel` `lock` and `lock-label` messages wipe correct entries
- `listLabels`, `lockLabel`, `lock`, `unlockedLabels`
- `delete` and `destroy`
- Browser-only guards (without `window`, without `IndexedDB`)
- Duplicate-create guard
- `getSeed` error on locked label

All tests pass with real WebCrypto (AES-GCM), `fake-indexeddb`, and a deterministic WebAuthn PRF mock.

## Testing

```
pnpm test -- test/vault/seed-vault.test.ts
# → 19 tests pass
```

## Acceptance criteria from #134

- [x] Vault v1: AES-GCM encrypted blob, key derived from WebAuthn signature
- [x] Unlock produces stealth signing seed in-memory only (no localStorage of plaintext)
- [x] Wipe on tab close (`pagehide` + `beforeunload`)
- [x] Cross-tab lock coordination (BroadcastChannel)
- [x] Threat model documented (`src/vault/README.md`)
- [x] Round-trip test: `create → lock → unlock` recovers identical seed
- [x] Explicit non-goal documented: not a wallet, not a key manager

Closes #134