### PR TITLE
test(leaks): add heap-snapshot regression harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,3 +88,31 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:fuzz
+
+  heap-regression:
+    name: Heap constructor regression (nightly)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Run constructor-level heap regression harness
+        run: pnpm test:heap-leak
+      - name: Upload heap regression artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: heap-regression-${{ github.run_id }}
+          path: |
+            heap-diff.json
+            heap-before.heapsnapshot
+            heap-after.heapsnapshot
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: Show canonical Prettier diff for leak harness
-        run: |
-          pnpm exec prettier --write test/leaks/heap-snapshot.test.ts test/leaks/README.md
-          git diff -- test/leaks/heap-snapshot.test.ts test/leaks/README.md
-          git checkout -- test/leaks/heap-snapshot.test.ts test/leaks/README.md
       - run: pnpm run format:check
       - run: pnpm build
       - run: pnpm api:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - name: Show canonical Prettier diff for leak harness
+        run: |
+          pnpm exec prettier --write test/leaks/heap-snapshot.test.ts test/leaks/README.md
+          git diff -- test/leaks/heap-snapshot.test.ts test/leaks/README.md
+          git checkout -- test/leaks/heap-snapshot.test.ts test/leaks/README.md
       - run: pnpm run format:check
       - run: pnpm build
       - run: pnpm api:check

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prepare": "husky",
     "test:fuzz": "FC_RUNS=100000 vitest run test/chains/stellar/properties.test.ts",
     "test:leak": "vitest run test/leaks/scan-leak.test.ts",
-    "test:heap-leak": "node --expose-gc ./node_modules/vitest/vitest.mjs run test/leaks/heap-snapshot.test.ts",
+    "test:heap-leak": "node --expose-gc ./node_modules/vitest/vitest.mjs run test/leaks/heap-snapshot.test.ts --pool=threads",
     "api:check": "api-extractor run --config api-extractor.json && api-extractor run --config api-extractor-evm.json && api-extractor run --config api-extractor-stellar.json && api-extractor run --config api-extractor-solana.json && api-extractor run --config api-extractor-ckb.json && api-extractor run --config api-extractor-vault.json"
   },
   "size-limit": [

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   ],
   "scripts": {
     "build": "tsup",
-    "test": "vitest run --exclude 'test/chains/stellar/properties.test.ts' --exclude 'test/leaks/scan-leak.test.ts' && pnpm --filter @wraith-protocol/sdk-svelte test",
+    "test": "vitest run --exclude 'test/chains/stellar/properties.test.ts' --exclude 'test/leaks/scan-leak.test.ts' --exclude 'test/leaks/heap-snapshot.test.ts' && pnpm --filter @wraith-protocol/sdk-svelte test",
     "docs": "typedoc",
     "test:watch": "vitest",
     "bench": "vitest bench --run",
@@ -58,6 +58,7 @@
     "prepare": "husky",
     "test:fuzz": "FC_RUNS=100000 vitest run test/chains/stellar/properties.test.ts",
     "test:leak": "vitest run test/leaks/scan-leak.test.ts",
+    "test:heap-leak": "node --expose-gc ./node_modules/vitest/vitest.mjs run test/leaks/heap-snapshot.test.ts",
     "api:check": "api-extractor run --config api-extractor.json && api-extractor run --config api-extractor-evm.json && api-extractor run --config api-extractor-stellar.json && api-extractor run --config api-extractor-solana.json && api-extractor run --config api-extractor-ckb.json && api-extractor run --config api-extractor-vault.json"
   },
   "size-limit": [
@@ -70,6 +71,7 @@
     {
       "name": "Stellar CJS (require)",
       "path": "dist/chains/stellar/index.cjs",
+      "import": "*",
       "limit": "20 KB"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     {
       "name": "Stellar CJS (require)",
       "path": "dist/chains/stellar/index.cjs",
-      "import": "*",
       "limit": "20 KB"
     }
   ],

--- a/test/leaks/README.md
+++ b/test/leaks/README.md
@@ -27,11 +27,11 @@ This script launches Vitest through Node with `--expose-gc` and writes these fil
 
 The following environment variables can be used to tune a run:
 
-| Variable                            | Default | Meaning                                                        |
-| ----------------------------------- | ------: | -------------------------------------------------------------- |
-| `HEAP_ANNOUNCEMENTS`                |  `1000` | Announcements generated for the scan workload                  |
-| `HEAP_SCANS`                        |   `100` | Number of measured scan iterations                             |
-| `HEAP_CONSTRUCTOR_GROWTH_THRESHOLD` |    `25` | Maximum retained-object growth allowed for any constructor     |
+| Variable                            | Default | Meaning                                                                           |
+| ----------------------------------- | ------: | --------------------------------------------------------------------------------- |
+| `HEAP_ANNOUNCEMENTS`                |  `1000` | Announcements generated for the scan workload                                     |
+| `HEAP_SCANS`                        |   `100` | Number of measured scan iterations                                                |
+| `HEAP_CONSTRUCTOR_GROWTH_THRESHOLD` |    `25` | Maximum retained-object growth allowed for any constructor                        |
 | `HEAP_LEAK_INJECT`                  |   unset | Set to `1` to deliberately retain `LeakSentinel` objects and prove the gate fails |
 
 ## Reproducibility

--- a/test/leaks/README.md
+++ b/test/leaks/README.md
@@ -27,12 +27,12 @@ This script launches Vitest through Node with `--expose-gc` and writes these fil
 
 The following environment variables can be used to tune a run:
 
-| Variable | Default | Meaning |
-| --- | ---: | --- |
-| `HEAP_ANNOUNCEMENTS` | `1000` | Announcements generated for the scan workload |
-| `HEAP_SCANS` | `100` | Number of measured scan iterations |
-| `HEAP_CONSTRUCTOR_GROWTH_THRESHOLD` | `25` | Maximum retained-object growth allowed for any constructor |
-| `HEAP_LEAK_INJECT` | unset | Set to `1` to deliberately retain `LeakSentinel` objects and prove the gate fails |
+| Variable                            | Default | Meaning                                                        |
+| ----------------------------------- | ------: | -------------------------------------------------------------- |
+| `HEAP_ANNOUNCEMENTS`                |  `1000` | Announcements generated for the scan workload                  |
+| `HEAP_SCANS`                        |   `100` | Number of measured scan iterations                             |
+| `HEAP_CONSTRUCTOR_GROWTH_THRESHOLD` |    `25` | Maximum retained-object growth allowed for any constructor     |
+| `HEAP_LEAK_INJECT`                  |   unset | Set to `1` to deliberately retain `LeakSentinel` objects and prove the gate fails |
 
 ## Reproducibility
 

--- a/test/leaks/README.md
+++ b/test/leaks/README.md
@@ -15,7 +15,7 @@ The harness requires explicit garbage collection so the before/after snapshots a
 pnpm test:heap-leak
 ```
 
-This script launches Vitest through Node with `--expose-gc` and writes these files in the repository root:
+This script launches Vitest through Node with `--expose-gc` and uses the thread pool so the test worker retains explicit GC access. It writes these files in the repository root:
 
 - `heap-before.heapsnapshot`
 - `heap-after.heapsnapshot`

--- a/test/leaks/README.md
+++ b/test/leaks/README.md
@@ -1,0 +1,53 @@
+# Leak regression harness
+
+The SDK has two complementary leak checks:
+
+- `scan-leak.test.ts` tracks the slope of `heapUsed` over repeated scans.
+- `heap-snapshot.test.ts` compares retained object counts by constructor between deterministic before/after V8 heap snapshots.
+
+The constructor-level harness is intended to catch slow retention bugs such as leaked `WeakRef` instances, buffers, or pooled objects that can hide inside a stable aggregate heap slope.
+
+## Running locally
+
+The harness requires explicit garbage collection so the before/after snapshots are comparable:
+
+```bash
+pnpm test:heap-leak
+```
+
+This script launches Vitest through Node with `--expose-gc` and writes these files in the repository root:
+
+- `heap-before.heapsnapshot`
+- `heap-after.heapsnapshot`
+- `heap-diff.json`
+
+`heap-diff.json` contains the complete constructor count delta, sorted by retained growth, plus any constructors that exceeded the configured threshold.
+
+## Configuration
+
+The following environment variables can be used to tune a run:
+
+| Variable | Default | Meaning |
+| --- | ---: | --- |
+| `HEAP_ANNOUNCEMENTS` | `1000` | Announcements generated for the scan workload |
+| `HEAP_SCANS` | `100` | Number of measured scan iterations |
+| `HEAP_CONSTRUCTOR_GROWTH_THRESHOLD` | `25` | Maximum retained-object growth allowed for any constructor |
+| `HEAP_LEAK_INJECT` | unset | Set to `1` to deliberately retain `LeakSentinel` objects and prove the gate fails |
+
+## Reproducibility
+
+Run `pnpm test:heap-leak` twice from the same commit with the same Node version and configuration. The harness forces GC before each snapshot and reports constructor counts using the V8 snapshot schema rather than process-level heap estimates. Small runtime bookkeeping differences are tolerated by the configured growth threshold; application-level retained growth above that threshold fails the test.
+
+## Regression proof
+
+To verify that the harness detects a known leak:
+
+```bash
+HEAP_LEAK_INJECT=1 pnpm test:heap-leak
+```
+
+That run intentionally keeps one `LeakSentinel` per scan alive. The constructor count should exceed the threshold and the test should fail. Do not enable this variable in normal CI.
+
+## CI
+
+The regular per-PR test job does not run the heap snapshot harness because heap snapshots are intentionally heavier and environment-sensitive. The scheduled nightly job runs `pnpm test:heap-leak` on Node 22 and uploads `heap-diff.json` together with the before/after snapshots as a GitHub Actions artifact, even when the regression gate fails.

--- a/test/leaks/heap-snapshot.test.ts
+++ b/test/leaks/heap-snapshot.test.ts
@@ -95,10 +95,7 @@ function constructorCounts(snapshotPath: string) {
   return counts;
 }
 
-function diffCounts(
-  before: Map<string, number>,
-  after: Map<string, number>,
-): ConstructorDiff[] {
+function diffCounts(before: Map<string, number>, after: Map<string, number>): ConstructorDiff[] {
   const constructors = new Set([...before.keys(), ...after.keys()]);
   return [...constructors]
     .map((constructor) => {
@@ -132,24 +129,14 @@ describe('scanAnnouncements - constructor-level heap regression', () => {
     );
 
     for (let i = 0; i < 10; i++) {
-      scanAnnouncements(
-        announcements,
-        keys.viewingKey,
-        keys.spendingPubKey,
-        keys.spendingScalar,
-      );
+      scanAnnouncements(announcements, keys.viewingKey, keys.spendingPubKey, keys.spendingScalar);
     }
 
     forceGc();
     const beforePath = writeSnapshot('heap-before.heapsnapshot');
 
     for (let i = 0; i < scans; i++) {
-      scanAnnouncements(
-        announcements,
-        keys.viewingKey,
-        keys.spendingPubKey,
-        keys.spendingScalar,
-      );
+      scanAnnouncements(announcements, keys.viewingKey, keys.spendingPubKey, keys.spendingScalar);
       if (injectLeak) injectedLeak.push(new LeakSentinel());
     }
 

--- a/test/leaks/heap-snapshot.test.ts
+++ b/test/leaks/heap-snapshot.test.ts
@@ -46,7 +46,9 @@ function generateAnnouncements(
   viewingPubKey: Uint8Array,
 ): Announcement[] {
   return Array.from({ length: count }, (_, i) => {
-    const stealth = generateStealthAddress(spendingPubKey, viewingPubKey);
+    const ephemeralSeed = new Uint8Array(32);
+    new DataView(ephemeralSeed.buffer).setUint32(28, i + 1, false);
+    const stealth = generateStealthAddress(spendingPubKey, viewingPubKey, ephemeralSeed);
     return {
       schemeId: SCHEME_ID,
       stealthAddress: stealth.stealthAddress,

--- a/test/leaks/heap-snapshot.test.ts
+++ b/test/leaks/heap-snapshot.test.ts
@@ -1,0 +1,177 @@
+import fs from 'fs';
+import path from 'path';
+import v8 from 'v8';
+import { describe, expect, it } from 'vitest';
+import type { Announcement } from '../../src/chains/stellar';
+import {
+  bytesToHex,
+  deriveStealthKeys,
+  generateStealthAddress,
+  scanAnnouncements,
+  SCHEME_ID,
+} from '../../src/chains/stellar';
+
+type HeapSnapshot = {
+  snapshot: {
+    meta: {
+      node_fields: string[];
+      node_types: unknown[][];
+    };
+  };
+  nodes: number[];
+  strings: string[];
+};
+
+type ConstructorDiff = {
+  constructor: string;
+  before: number;
+  after: number;
+  growth: number;
+};
+
+class LeakSentinel {
+  readonly payload = new Uint8Array(8 * 1024);
+}
+
+const injectedLeak: LeakSentinel[] = [];
+
+function envInt(name: string, fallback: number) {
+  const value = Number.parseInt(process.env[name] ?? '', 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+function generateAnnouncements(
+  count: number,
+  spendingPubKey: Uint8Array,
+  viewingPubKey: Uint8Array,
+): Announcement[] {
+  return Array.from({ length: count }, (_, i) => {
+    const stealth = generateStealthAddress(spendingPubKey, viewingPubKey);
+    return {
+      schemeId: SCHEME_ID,
+      stealthAddress: stealth.stealthAddress,
+      caller: `G${'A'.repeat(55)}`,
+      ephemeralPubKey: bytesToHex(stealth.ephemeralPubKey),
+      metadata: bytesToHex(Uint8Array.of(stealth.viewTag)),
+      ledger: i,
+    };
+  });
+}
+
+function forceGc() {
+  if (typeof global.gc !== 'function') {
+    throw new Error('Heap regression harness requires Node to run with --expose-gc');
+  }
+  global.gc();
+  global.gc();
+}
+
+function writeSnapshot(filename: string) {
+  const output = path.join(process.cwd(), filename);
+  v8.writeHeapSnapshot(output);
+  return output;
+}
+
+function constructorCounts(snapshotPath: string) {
+  const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8')) as HeapSnapshot;
+  const fields = snapshot.snapshot.meta.node_fields;
+  const nodeTypes = snapshot.snapshot.meta.node_types[0] as string[];
+  const width = fields.length;
+  const typeOffset = fields.indexOf('type');
+  const nameOffset = fields.indexOf('name');
+
+  if (typeOffset < 0 || nameOffset < 0) {
+    throw new Error('Unsupported V8 heap snapshot: missing node type/name fields');
+  }
+
+  const counts = new Map<string, number>();
+  for (let offset = 0; offset < snapshot.nodes.length; offset += width) {
+    const nodeType = nodeTypes[snapshot.nodes[offset + typeOffset]];
+    if (nodeType !== 'object' && nodeType !== 'native') continue;
+
+    const name = snapshot.strings[snapshot.nodes[offset + nameOffset]] || '(anonymous)';
+    counts.set(name, (counts.get(name) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function diffCounts(before: Map<string, number>, after: Map<string, number>): ConstructorDiff[] {
+  const constructors = new Set([...before.keys(), ...after.keys()]);
+  return [...constructors]
+    .map((constructor) => {
+      const beforeCount = before.get(constructor) ?? 0;
+      const afterCount = after.get(constructor) ?? 0;
+      return {
+        constructor,
+        before: beforeCount,
+        after: afterCount,
+        growth: afterCount - beforeCount,
+      };
+    })
+    .filter((entry) => entry.growth !== 0)
+    .sort((a, b) => b.growth - a.growth || a.constructor.localeCompare(b.constructor));
+}
+
+describe('scanAnnouncements - constructor-level heap regression', () => {
+  it('fails when retained constructor counts grow beyond the configured threshold', () => {
+    const announcementsCount = envInt('HEAP_ANNOUNCEMENTS', 1_000);
+    const scans = envInt('HEAP_SCANS', 100);
+    const threshold = envInt('HEAP_CONSTRUCTOR_GROWTH_THRESHOLD', 25);
+    const injectLeak = process.env.HEAP_LEAK_INJECT === '1';
+
+    const signature = new Uint8Array(64);
+    crypto.getRandomValues(signature);
+    const keys = deriveStealthKeys(signature);
+    const announcements = generateAnnouncements(
+      announcementsCount,
+      keys.spendingPubKey,
+      keys.viewingPubKey,
+    );
+
+    for (let i = 0; i < 10; i++) {
+      scanAnnouncements(
+        announcements,
+        keys.viewingKey,
+        keys.spendingPubKey,
+        keys.spendingScalar,
+      );
+    }
+
+    forceGc();
+    const beforePath = writeSnapshot('heap-before.heapsnapshot');
+
+    for (let i = 0; i < scans; i++) {
+      scanAnnouncements(
+        announcements,
+        keys.viewingKey,
+        keys.spendingPubKey,
+        keys.spendingScalar,
+      );
+      if (injectLeak) injectedLeak.push(new LeakSentinel());
+    }
+
+    forceGc();
+    const afterPath = writeSnapshot('heap-after.heapsnapshot');
+
+    const before = constructorCounts(beforePath);
+    const after = constructorCounts(afterPath);
+    const diff = diffCounts(before, after);
+    const regressions = diff.filter((entry) => entry.growth > threshold);
+
+    fs.writeFileSync(
+      path.join(process.cwd(), 'heap-diff.json'),
+      `${JSON.stringify(
+        {
+          config: { announcementsCount, scans, threshold, injectLeak },
+          regressions,
+          diff,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+
+    console.log('Largest retained constructor growth:', diff.slice(0, 20));
+    expect(regressions, `Retained constructor growth exceeded ${threshold}`).toEqual([]);
+  });
+});

--- a/test/leaks/heap-snapshot.test.ts
+++ b/test/leaks/heap-snapshot.test.ts
@@ -119,8 +119,8 @@ describe('scanAnnouncements - constructor-level heap regression', () => {
     const threshold = envInt('HEAP_CONSTRUCTOR_GROWTH_THRESHOLD', 25);
     const injectLeak = process.env.HEAP_LEAK_INJECT === '1';
 
-    const signature = new Uint8Array(64);
-    crypto.getRandomValues(signature);
+    // Keep the workload deterministic so same-commit snapshot runs are comparable.
+    const signature = Uint8Array.from({ length: 64 }, (_, index) => (index * 17 + 29) & 0xff);
     const keys = deriveStealthKeys(signature);
     const announcements = generateAnnouncements(
       announcementsCount,

--- a/test/leaks/heap-snapshot.test.ts
+++ b/test/leaks/heap-snapshot.test.ts
@@ -95,7 +95,10 @@ function constructorCounts(snapshotPath: string) {
   return counts;
 }
 
-function diffCounts(before: Map<string, number>, after: Map<string, number>): ConstructorDiff[] {
+function diffCounts(
+  before: Map<string, number>,
+  after: Map<string, number>,
+): ConstructorDiff[] {
   const constructors = new Set([...before.keys(), ...after.keys()]);
   return [...constructors]
     .map((constructor) => {


### PR DESCRIPTION
## Summary

Adds a deterministic V8 heap-snapshot regression harness for the SDK leak test suite.

- captures heap snapshots before and after repeated scan workloads
- compares retained objects at constructor level
- supports configurable regression thresholds
- requires deterministic GC via `--expose-gc`
- includes an intentional leak-injection mode to verify that the harness fails on a real regression
- writes a machine-readable `heap-diff.json` report
- runs the harness in the nightly CI job and uploads the report as an artifact
- documents local usage, thresholds, and failure interpretation

## Validation

The harness is designed to:
- pass when retained constructor growth stays within the configured threshold
- fail when deliberate retained-object growth is injected
- produce a reproducible constructor-level diff for CI inspection

## Issue

Closes #182